### PR TITLE
Cosmosis interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
             pip install numpy>=1.15
             pip install -r requirements.txt
             pip install -r dev-requirements.txt
-            CC=gcc CXX=g++ FC=gfortran pip install cosmosis-standalone==0.0.8
             pip install .
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
             sudo apt-get update && sudo apt-get install -y gcc g++ gfortran swig libhdf5-serial-dev
             python3 -m venv venv
             . venv/bin/activate
+            export CC=gcc
+            export FC=gfortran
+            export CXX=g++
             pip install -U pip setuptools wheel
             pip install numpy>=1.15
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
             pip install numpy>=1.15
             pip install -r requirements.txt
             pip install -r dev-requirements.txt
+            CC=gcc CXX=g++ FC=gfortran pip install cosmosis-standalone==0.0.8
             pip install .
 
       - save_cache:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ CC=gcc-7 CXX=g++-7 FC=gfortran pip install cosmosis-standalone
 Currently the Clang compiler cannot compile cosmosis.
 
 You can then run with:
+
 ```bash
 cd examples
 firecrown sample cosmicshear.yaml

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can then run with:
 
 ```bash
 cd examples
-firecrown sample cosmicshear.yaml
+firecrown run-cosmosis cosmicshear.yaml
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ will run an example problem.
 
 See the example in the examples folder for more details.
 
+## Sampling
+
+To use CosmoSIS to sample cosmological parameters, first install cosmosis-standalone.
+You will need to specify compilers on install, for example:
+
+```bash
+CC=gcc-7 CXX=g++-7 FC=gfortran pip install cosmosis-standalone
+```
+
+Currently the Clang compiler cannot compile cosmosis.
+
+You can then run with:
+```bash
+cd examples
+firecrown sample cosmicshear.yaml
+```
+
 ## API
 
 See the [API documentation](API.md) for details.

--- a/bin/firecrown
+++ b/bin/firecrown
@@ -36,7 +36,7 @@ def run(action, config):
         print('loglike:', loglike)
         print('stats:', pprint.pformat(stats))
 
-    elif action == 'sample':
+    elif action == 'run-cosmosis':
         firecrown.run_cosmosis(config, data)
 
 

--- a/bin/firecrown
+++ b/bin/firecrown
@@ -25,6 +25,9 @@ def run(action, config):
             if p in config['parameters']:
                 val = config['parameters'][p]
                 if isinstance(val, list):
+                    if len(val)!=3:
+                        raise ValueError("Parameters should be specified"
+                                         "either as one param or three")
                     val = val[1]
                 params[p] = val
 

--- a/bin/firecrown
+++ b/bin/firecrown
@@ -25,7 +25,7 @@ def run(action, config):
             if p in config['parameters']:
                 val = config['parameters'][p]
                 if isinstance(val, list):
-                    val=val[1]
+                    val = val[1]
                 params[p] = val
 
         cosmo = pyccl.Cosmology(**params)

--- a/bin/firecrown
+++ b/bin/firecrown
@@ -3,7 +3,6 @@ import pprint
 import click
 import firecrown
 import pyccl
-import firecrown.cosmosis
 
 
 @click.command()
@@ -33,7 +32,7 @@ def run(action, config):
         print('stats:', pprint.pformat(stats))
 
     elif action == 'sample':
-        firecrown.cosmosis.run(config, data)
+        firecrown.run_cosmosis(config, data)
 
 
 if __name__ == '__main__':

--- a/bin/firecrown
+++ b/bin/firecrown
@@ -14,6 +14,7 @@ def run(action, config):
     Also, run some ACTION on a CONFIG file."""
     config, data = firecrown.parse(config)
     print("Watch out! Here comes a firecrown!")
+    print("config file:\n", pprint.pformat(config))
 
     # FIXME: stubby code for testing
     if action == 'compute':

--- a/bin/firecrown
+++ b/bin/firecrown
@@ -3,6 +3,7 @@ import pprint
 import click
 import firecrown
 import pyccl
+import firecrown.cosmosis
 
 
 @click.command()
@@ -14,20 +15,25 @@ def run(action, config):
     Also, run some ACTION on a CONFIG file."""
     config, data = firecrown.parse(config)
     print("Watch out! Here comes a firecrown!")
-    print("config file:\n", pprint.pformat(config))
 
     # FIXME: stubby code for testing
     if action == 'compute':
         params = {}
         for p in ['Omega_k', 'Omega_b', 'Omega_c', 'h',
-                  'n_s', 'sigma8', 'w0', 'wa']:
+                  'n_s', 'A_s', 'w0', 'wa']:
             if p in config['parameters']:
-                params[p] = config['parameters'][p]
+                val = config['parameters'][p]
+                if isinstance(val, list):
+                    val=val[1]
+                params[p] = val
 
         cosmo = pyccl.Cosmology(**params)
         loglike, stats = firecrown.compute_loglike(cosmo=cosmo, data=data)
         print('loglike:', loglike)
         print('stats:', pprint.pformat(stats))
+
+    elif action == 'sample':
+        firecrown.cosmosis.run(config, data)
 
 
 if __name__ == '__main__':

--- a/bin/firecrown
+++ b/bin/firecrown
@@ -15,6 +15,7 @@ def run(action, config):
     config, data = firecrown.parse(config)
     print("Watch out! Here comes a firecrown!")
     print("config file:\n", pprint.pformat(config))
+    print("data:\n", pprint.pformat(data))
 
     # FIXME: stubby code for testing
     if action == 'compute':

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 flake8
 pytest
 nose
-cosmosis-standalone==0.0.8
+cosmosis-standalone==0.0.9

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 flake8
 pytest
 nose
+cosmosis-standalone==0.0.8

--- a/examples/cosmicshear.yaml
+++ b/examples/cosmicshear.yaml
@@ -14,14 +14,18 @@ parameters:
 
 
 sampler:
-  sampler: test
+  sampler: grid
   output: chain.txt
   debug: True
+  quiet: False
+  mpi: True
   test:
     fatal_errors: True
   emcee:
     walkers: 10
     nsample: 20
+  grid:
+    nsample_dimension: 5
   fisher:
     step_size: 0.02
 

--- a/examples/cosmicshear.yaml
+++ b/examples/cosmicshear.yaml
@@ -1,16 +1,30 @@
 parameters:
   Omega_k: 0.0
-  Omega_c: 0.27
+  Omega_c: [0.25, 0.27, 0.32]
   Omega_b: 0.045
   h: 0.67
   n_s: 0.96
-  sigma8: 0.8
+  A_s: [2.0e-9, 2.1e-9, 2.2e-9]
   w0: -1.0
   wa: 0.0
 
   # lens bin zero
   src0_delta_z: 0.0
   src1_delta_z: 0.0
+
+
+sampler:
+  sampler: test
+  output: chain.txt
+  debug: True
+  test:
+    fatal_errors: True
+  emcee:
+    walkers: 10
+    nsample: 20
+  fisher:
+    step_size: 0.02
+
 
 two_point:
   module: firecrown.ccl.two_point

--- a/examples/cosmicshear.yaml
+++ b/examples/cosmicshear.yaml
@@ -1,6 +1,6 @@
 parameters:
   Omega_k: 0.0
-  Omega_c: [0.25, 0.27, 0.32]
+  Omega_c: [0.25, 0.27, 0.32]  # [min, start, max]
   Omega_b: 0.045
   h: 0.67
   n_s: 0.96
@@ -19,6 +19,7 @@ sampler:
   debug: True
   quiet: False
   mpi: True
+  # parameters for individual samplers:
   test:
     fatal_errors: True
   emcee:

--- a/examples/cosmicshear.yaml
+++ b/examples/cosmicshear.yaml
@@ -1,6 +1,9 @@
 parameters:
   Omega_k: 0.0
-  Omega_c: [0.25, 0.27, 0.32]  # [min, start, max]
+  # Parameters varied with cosmosis
+  # need a min value, starting point, and max value,
+  # like so:
+  Omega_c: [0.25, 0.27, 0.32]
   Omega_b: 0.045
   h: 0.67
   n_s: 0.96

--- a/examples/cosmicshear.yaml
+++ b/examples/cosmicshear.yaml
@@ -13,7 +13,7 @@ parameters:
   src1_delta_z: 0.0
 
 
-sampler:
+cosmosis:
   sampler: grid
   output: chain.txt
   debug: True

--- a/examples/generate_cosmicshear_data.py
+++ b/examples/generate_cosmicshear_data.py
@@ -9,7 +9,7 @@ cosmo = ccl.Cosmology(
     Omega_k=0.0,
     w0=-1.0,
     wa=0.0,
-    sigma8=0.8,
+    A_s=2.1e-9,
     n_s=0.96,
     h=0.67)
 

--- a/firecrown/__init__.py
+++ b/firecrown/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 from .loglike import compute_loglike
 from .parser import parse
+from .cosmosis import run_cosmosis

--- a/firecrown/__init__.py
+++ b/firecrown/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
 from .loglike import compute_loglike
 from .parser import parse
-from .cosmosis import run_cosmosis
+from .cosmosis.run import run_cosmosis

--- a/firecrown/cosmosis/__init__.py
+++ b/firecrown/cosmosis/__init__.py
@@ -1,0 +1,1 @@
+from .api import run

--- a/firecrown/cosmosis/__init__.py
+++ b/firecrown/cosmosis/__init__.py
@@ -1,1 +1,1 @@
-from .api import run
+from .run import run_cosmosis

--- a/firecrown/cosmosis/__init__.py
+++ b/firecrown/cosmosis/__init__.py
@@ -1,1 +1,0 @@
-from .run import run_cosmosis

--- a/firecrown/cosmosis/api.py
+++ b/firecrown/cosmosis/api.py
@@ -1,0 +1,87 @@
+import pathlib
+
+THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
+COSMOSIS_INTERFACE = str(THIS_DIRECTORY.joinpath('interface.py'))
+
+
+def run(config, data):
+    from cosmosis.runtime.module import Module
+    from cosmosis.runtime.pipeline import LikelihoodPipeline
+    from cosmosis.main import run_cosmosis
+
+    # Name of the sampler to use
+
+    # Set up a single cosmosis module to use as the interface
+    module = Module('firecrown', COSMOSIS_INTERFACE)
+    module.setup_functions(data)
+    modules = [module]
+
+    ini = make_cosmosis_config(config)
+    values = make_cosmosis_values(config)
+
+    # Whether to use MPI
+    use_mpi = config['sampler'].get('mpi', False)
+    if use_mpi:
+        pool = MPIPool()
+    else:
+        pool = None
+        print("Running single core")
+
+    pipeline = LikelihoodPipeline(load=False, values=values, priors=None)
+    pipeline.modules = modules
+
+    run_cosmosis(None, pool=pool, ini=ini, pipeline=pipeline, values=values)
+
+
+    if use_mpi:
+        pool.close()
+
+
+def make_cosmosis_config(config):
+    from cosmosis.runtime.config import Inifile
+
+    # Some general options
+    config = config['sampler']
+    sampler_name = config['sampler']
+    output_file = config['output']
+    debug = config.get('debug', False)
+    quiet = config.get('quiet', False)
+    root = "" # Dummy value to stop cosmosis complaining
+
+    # Make into a pair dictionary with the right cosmosis sections
+    cosmosis_options = {
+        ("runtime","root") : root,  
+        ("runtime","sampler") : sampler_name,
+        ("output","filename") : output_file,
+        ("pipeline","debug") : str(debug),
+        ("pipeline","quiet") : str(quiet),
+    }
+
+    # Set all the sampler configuration options
+    sampler_config = config.get(sampler_name, {})
+    for key,val in sampler_config.items():
+        cosmosis_options[(sampler_name, key)] = str(val)
+
+    # Convert into cosmosis Inifile format.
+    cosmosis_config = Inifile(None, override=cosmosis_options)
+
+    return cosmosis_config
+
+
+def make_cosmosis_values(config):
+    from cosmosis.runtime.config import Inifile
+
+    params = config['parameters']
+    values = {}
+    for p,v in params.items():
+        key = ('params',p)
+        if isinstance(v,list):
+            values[key] = ' '.join(str(x) for x in v)
+        else:
+            values[key] = str(v)
+
+    cosmosis_values = Inifile(None, override=values)
+
+    return cosmosis_values
+
+

--- a/firecrown/cosmosis/api.py
+++ b/firecrown/cosmosis/api.py
@@ -1,5 +1,9 @@
 import pathlib
 
+# Locate the path to this directory
+# For fiddly reasons that make a great deal of sense in an entirely
+# different context to this one, we pass cosmosis a full path
+# to the interface file
 THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
 COSMOSIS_INTERFACE = str(THIS_DIRECTORY.joinpath('interface.py'))
 
@@ -8,14 +12,17 @@ def run(config, data):
     from cosmosis.runtime.module import Module
     from cosmosis.runtime.pipeline import LikelihoodPipeline
     from cosmosis.main import run_cosmosis
+    from cosmosis.runtime.mpi_pool import MPIPool
 
-    # Name of the sampler to use
 
-    # Set up a single cosmosis module to use as the interface
+    # Set up a single cosmosis module, which will be the interface
+    # file in the same directory as this one
     module = Module('firecrown', COSMOSIS_INTERFACE)
     module.setup_functions(data)
     modules = [module]
 
+    # Extract the bits of the config file that
+    # cosmosis wants
     ini = make_cosmosis_config(config)
     values = make_cosmosis_values(config)
 
@@ -27,9 +34,11 @@ def run(config, data):
         pool = None
         print("Running single core")
 
+    # Build the pipeline that evaluates the likelihood
     pipeline = LikelihoodPipeline(load=False, values=values, priors=None)
     pipeline.modules = modules
 
+    # Actually run the thing
     run_cosmosis(None, pool=pool, ini=ini, pipeline=pipeline, values=values)
 
 

--- a/firecrown/cosmosis/api.py
+++ b/firecrown/cosmosis/api.py
@@ -1,4 +1,5 @@
 import pathlib
+import os
 
 # Locate the path to this directory
 # For fiddly reasons that make a great deal of sense in an entirely
@@ -9,53 +10,150 @@ COSMOSIS_INTERFACE = str(THIS_DIRECTORY.joinpath('interface.py'))
 
 
 def run(config, data):
-    from cosmosis.runtime.module import Module
-    from cosmosis.runtime.pipeline import LikelihoodPipeline
+    """Run CosmoSIS on the problem.
+
+    This requires the following parameters 'sampler' section
+    of the config:
+
+      sampler - name of sampler to use, e.g. emcee, multinest, grid, ...
+      output - name of file to save to
+
+
+    Parameters
+    ----------
+    config : dict
+        Configuration info, usually read directly from the YAML file
+    data : dict
+        The result of calling `firecrown.config.parse` on an input YAML
+        config.
+
+    """
     from cosmosis.main import run_cosmosis
-    from cosmosis.runtime.mpi_pool import MPIPool
-
-
-    # Set up a single cosmosis module, which will be the interface
-    # file in the same directory as this one
-    module = Module('firecrown', COSMOSIS_INTERFACE)
-    module.setup_functions(data)
-    modules = [module]
 
     # Extract the bits of the config file that
     # cosmosis wants
-    ini = make_cosmosis_config(config)
-    values = make_cosmosis_values(config)
-
-    # Whether to use MPI
-    use_mpi = config['sampler'].get('mpi', False)
-    if use_mpi:
-        pool = MPIPool()
-    else:
-        pool = None
-        print("Running single core")
-
-    # Build the pipeline that evaluates the likelihood
-    pipeline = LikelihoodPipeline(load=False, values=values, priors=None)
-    pipeline.modules = modules
+    ini = _make_cosmosis_config(config['sampler'])
+    values = _make_cosmosis_values(config['parameters'])
+    pool = _make_parallel_pool(config['sampler'])
+    pipeline = _make_cosmosis_pipeline(data, values, pool)
 
     # Actually run the thing
     run_cosmosis(None, pool=pool, ini=ini, pipeline=pipeline, values=values)
 
-
-    if use_mpi:
+    if pool is not None:
         pool.close()
 
 
-def make_cosmosis_config(config):
+def _make_parallel_pool(config):
+    """ Set up a parallel process pool.
+
+    Parameters
+    ----------
+
+    config: dict
+        Sampler configuration section of the input
+
+    Will look for the 'mpi' command in the parallel section
+
+    Returns
+    -------
+
+    pool: CosmoSIS MPIPool object
+        parallel process pool
+    """
+
+    from cosmosis.runtime.mpi_pool import MPIPool
+
+    # There is a reason to make the user actively
+    # request to use MPI rather than just checking - 
+    # on many systems, including, importantly, NERSC,
+    # trying to import MPI when not running under the
+    # MPI environment will cause a crash
+    use_mpi = config.get('mpi', False)
+
+    if use_mpi:
+        pool = MPIPool()
+        if pool.size == 1:
+            print("Have mpi set to True but one process.")
+            print("I will ignore and run in serial mode.")
+            pool = None
+    else:
+        pool = None
+        print("Running in serial mode (one process).")
+
+    return pool
+
+
+
+def _make_cosmosis_pipeline(data, values, pool):
+    """ Build a CosmoSIS pipeline.
+
+    Parameters
+    ----------
+
+    values: Inifile
+        Cosmosis object representing the input parameter values
+
+    Returns
+    -------
+
+    pipeline: CosmoSIS pipeline objects
+        Instantiated pipeline but with no modules
+    """
+    from cosmosis.runtime.pipeline import LikelihoodPipeline
+    from cosmosis.runtime.module import Module
+    from cosmosis.runtime.utils import stdout_redirected
+
+    # Lie to CosmoSIS about where it is installed.
+    os.environ['COSMOSIS_SRC_DIR'] = '.'
+
+    # Build the pipeline that evaluates the likelihood.
+    # We avoid printing various bits of output info by silencing stdout on
+    # worker nodes.
+    if (pool is None) or pool.is_master():
+        pipeline = LikelihoodPipeline(load=False, values=values, priors=None)
+    else:
+        with stdout_redirected():
+            pipeline = LikelihoodPipeline(load=False, values=values, priors=None)
+
+    sys.stdout.flush()
+    # Set up a single cosmosis module, which will be the interface
+    # file in the same directory as this one
+    module = Module('firecrown', COSMOSIS_INTERFACE)
+    module.setup_functions(data)
+    pipeline.modules = [module]
+
+    return pipeline
+
+
+
+def _make_cosmosis_config(config):
+    """ Extract a cosmosis configuration object from a config dict
+
+    Parameters
+    ----------
+    config: dict
+        Configuration dictionary of 'sampler' section
+
+    Returns
+    -------
+
+    cosmosis_config: Inifile
+        object to use to build cosmosis pipeline
+    
+    """
     from cosmosis.runtime.config import Inifile
 
     # Some general options
-    config = config['sampler']
     sampler_name = config['sampler']
     output_file = config['output']
     debug = config.get('debug', False)
     quiet = config.get('quiet', False)
     root = "" # Dummy value to stop cosmosis complaining
+
+    # Passive-aggressive error message
+    if sampler_name == 'fisher':
+        raise ValueError("The Fisher matrix sampler does not work since the refactor - sorry.")
 
     # Make into a pair dictionary with the right cosmosis sections
     cosmosis_options = {
@@ -66,7 +164,9 @@ def make_cosmosis_config(config):
         ("pipeline","quiet") : str(quiet),
     }
 
-    # Set all the sampler configuration options
+    # Set all the sampler configuration options from the
+    # appropriate section of the config (e.g., the "grid"
+    # section if using the grid sampler, etc.)
     sampler_config = config.get(sampler_name, {})
     for key,val in sampler_config.items():
         cosmosis_options[(sampler_name, key)] = str(val)
@@ -77,10 +177,23 @@ def make_cosmosis_config(config):
     return cosmosis_config
 
 
-def make_cosmosis_values(config):
+def _make_cosmosis_values(params):
+    """ Extract a cosmosis values object from a config dict
+
+    Parameters
+    ----------
+    params: dict
+        Configuration dictionary of 'sampler' section and options
+
+    Returns
+    -------
+
+    cosmosis_values: Inifile
+        object to use to build cosmosis parameter ranges/values
+    
+    """
     from cosmosis.runtime.config import Inifile
 
-    params = config['parameters']
     values = {}
     for p,v in params.items():
         key = ('params',p)

--- a/firecrown/cosmosis/api.py
+++ b/firecrown/cosmosis/api.py
@@ -1,5 +1,6 @@
 import pathlib
 import os
+import sys
 
 # Locate the path to this directory
 # For fiddly reasons that make a great deal of sense in an entirely

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -27,8 +27,8 @@ def execute(block, data):
     ccl_values = {p: block['params', p] for p in ccl_params}
     cosmo = pyccl.Cosmology(**ccl_values)
 
-    # Put all the other parameters in the data dictionary,
-    # from the ones cosmosis sent us.
+    # Put all the parameters in the data dictionary,
+    # both CCL-related and others, like nuisance params.
     all_params = data['parameters'].keys()
     for p in all_params:
         data['parameters'][p] = block['params', p]

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -40,7 +40,7 @@ def execute(block, data):
     block['likelihoods', 'firecrown_like'] = loglike
 
     # Unless in quiet mode, print out what we have done
-    if not data['cosmosis']['quiet']:
+    if not data['cosmosis'].get(quiet, True):
         print("params = {}".format(data['parameters']))
         print(f"loglike = {loglike}\n", flush=True)
 

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -3,7 +3,6 @@
 # - the module is not reloaded
 import firecrown
 import pyccl
-import sys
 
 
 def setup(data):
@@ -40,7 +39,7 @@ def execute(block, data):
     block['likelihoods', 'firecrown_like'] = loglike
 
     # Unless in quiet mode, print out what we have done
-    if not data['cosmosis'].get(quiet, True):
+    if not data['cosmosis'].get("quiet", True):
         print("params = {}".format(data['parameters']))
         print(f"loglike = {loglike}\n", flush=True)
 

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -40,7 +40,7 @@ def execute(block, data):
     block['likelihoods', 'firecrown_like'] = loglike
 
     # Unless in quiet mode, print out what we have done
-    if not data['sampler']['quiet']:
+    if not data['cosmosis']['quiet']:
         print("params = {}".format(data['parameters']))
         print(f"loglike = {loglike}\n")
         # Useful to flush when running under MPI, to avoid

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -3,6 +3,7 @@
 # - the module is not reloaded
 import firecrown
 import pyccl
+import sys
 
 def setup(data):
     return data
@@ -22,7 +23,10 @@ def execute(block, data):
     # Unless in quiet mode, print out what we have done
     if not data['sampler']['quiet']:
         print(f"params = {params}\nloglike = {loglike}\n")
+        # Useful to flush when running under MPI, to avoid
+        # buffering
+        sys.stdout.flush()
 
     # Signal success.  An exception anywhere above will
-    # be converted to an error status
+    # be converted to a -inf likelihood by default.
     return 0

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -11,11 +11,16 @@ def setup(data):
 
 
 def execute(block, data):
-    # TODO: Replace this with proper parameter handling when ready
-    required_params = ['Omega_k', 'Omega_b', 'Omega_c',
-                       'h', 'n_s', 'A_s', 'w0', 'wa']
-    params = {p: block['params', p] for p in required_params}
-    cosmo = pyccl.Cosmology(**params)
+
+    # Create CCL cosmology
+    ccl_params = ['Omega_k', 'Omega_b', 'Omega_c',
+                  'h', 'n_s', 'A_s', 'w0', 'wa']
+    ccl_values = {p: block['params', p] for p in ccl_params}
+    cosmo = pyccl.Cosmology(**ccl_values)
+
+    all_params = data['parameters'].keys()
+    for p in all_params:
+        data['parameters'][p] = block['params', p]
 
     # Call out to the log likelihood
     loglike, stats = firecrown.compute_loglike(cosmo=cosmo, data=data)
@@ -25,7 +30,7 @@ def execute(block, data):
 
     # Unless in quiet mode, print out what we have done
     if not data['sampler']['quiet']:
-        print(f"params = {params}")
+        print("params = {}".format(data['parameters']))
         print(f"loglike = {loglike}\n")
         # Useful to flush when running under MPI, to avoid
         # buffering

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -1,22 +1,25 @@
 # For technical reasons this does have to be an absolute
-# import. This has no effect on anything in this case 
+# import. This has no effect on anything in this case
 # - the module is not reloaded
 import firecrown
 import pyccl
 import sys
 
+
 def setup(data):
     return data
 
+
 def execute(block, data):
     # TODO: Replace this with proper parameter handling when ready
-    required_params = ['Omega_k', 'Omega_b', 'Omega_c', 'h', 'n_s', 'A_s', 'w0', 'wa']
+    required_params = ['Omega_k', 'Omega_b', 'Omega_c',
+                       'h', 'n_s', 'A_s', 'w0', 'wa']
     params = {p: block['params', p] for p in required_params}
     cosmo = pyccl.Cosmology(**params)
 
     # Call out to the log likelihood
     loglike, stats = firecrown.compute_loglike(cosmo=cosmo, data=data)
-    
+
     # Send result back to cosmosis
     block['likelihoods', 'firecrown_like'] = loglike
 

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -7,10 +7,19 @@ import sys
 
 
 def setup(data):
+    # In most cosmosis modules this function
+    # is a bit more complicated!  We are hacking it
+    # a bit here - normally the input to this function
+    # is the configuration information for the module.
     return data
 
 
 def execute(block, data):
+    # Calculate the firecrown likelihood as a module
+    # This function, which isn't designed for end users,
+    # is the main connection between cosmosis and firecrown.
+    # CosmoSIS builds the block, and passes it to us here.
+    # The block contains all the sample parameters.
 
     # Create CCL cosmology
     ccl_params = ['Omega_k', 'Omega_b', 'Omega_c',
@@ -18,6 +27,8 @@ def execute(block, data):
     ccl_values = {p: block['params', p] for p in ccl_params}
     cosmo = pyccl.Cosmology(**ccl_values)
 
+    # Put all the other parameters in the data dictionary,
+    # from the ones cosmosis sent us.
     all_params = data['parameters'].keys()
     for p in all_params:
         data['parameters'][p] = block['params', p]

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -1,19 +1,28 @@
-
-import pyccl
+# For technical reasons this does have to be an absolute
+# import. This has no effect on anything in this case 
+# - the module is not reloaded
 import firecrown
+import pyccl
 
 def setup(data):
-    print(data)
     return data
 
 def execute(block, data):
-    # Replace with proper parameter handling when ready
+    # TODO: Replace this with proper parameter handling when ready
     required_params = ['Omega_k', 'Omega_b', 'Omega_c', 'h', 'n_s', 'A_s', 'w0', 'wa']
     params = {p: block['params', p] for p in required_params}
-    print(params)
     cosmo = pyccl.Cosmology(**params)
-    print(cosmo)
+
+    # Call out to the log likelihood
     loglike, stats = firecrown.compute_loglike(cosmo=cosmo, data=data)
+    
+    # Send result back to cosmosis
     block['likelihoods', 'firecrown_like'] = loglike
 
+    # Unless in quiet mode, print out what we have done
+    if not data['sampler']['quiet']:
+        print(f"params = {params}\nloglike = {loglike}\n")
+
+    # Signal success.  An exception anywhere above will
+    # be converted to an error status
     return 0

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -25,7 +25,8 @@ def execute(block, data):
 
     # Unless in quiet mode, print out what we have done
     if not data['sampler']['quiet']:
-        print(f"params = {params}\nloglike = {loglike}\n")
+        print(f"params = {params}")
+        print(f"loglike = {loglike}\n")
         # Useful to flush when running under MPI, to avoid
         # buffering
         sys.stdout.flush()

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -42,10 +42,7 @@ def execute(block, data):
     # Unless in quiet mode, print out what we have done
     if not data['cosmosis']['quiet']:
         print("params = {}".format(data['parameters']))
-        print(f"loglike = {loglike}\n")
-        # Useful to flush when running under MPI, to avoid
-        # buffering
-        sys.stdout.flush()
+        print(f"loglike = {loglike}\n", flush=True)
 
     # Signal success.  An exception anywhere above will
     # be converted to a -inf likelihood by default.

--- a/firecrown/cosmosis/interface.py
+++ b/firecrown/cosmosis/interface.py
@@ -1,0 +1,19 @@
+
+import pyccl
+import firecrown
+
+def setup(data):
+    print(data)
+    return data
+
+def execute(block, data):
+    # Replace with proper parameter handling when ready
+    required_params = ['Omega_k', 'Omega_b', 'Omega_c', 'h', 'n_s', 'A_s', 'w0', 'wa']
+    params = {p: block['params', p] for p in required_params}
+    print(params)
+    cosmo = pyccl.Cosmology(**params)
+    print(cosmo)
+    loglike, stats = firecrown.compute_loglike(cosmo=cosmo, data=data)
+    block['likelihoods', 'firecrown_like'] = loglike
+
+    return 0

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -91,14 +91,21 @@ def _make_cosmosis_pipeline(data, values, pool):
     Parameters
     ----------
 
+    data: dict
+        The data object parse'd from an input yaml file.
+        This is passed as-is to the likelihood function
+
     values: Inifile
         Cosmosis object representing the input parameter values
+
+    pool: MPIPool or None
+        If using MPI parallelism, a CosmoSIS pool object.
 
     Returns
     -------
 
     pipeline: CosmoSIS pipeline objects
-        Instantiated pipeline but with no modules
+        Instantiated pipeline ready to run.
     """
     from cosmosis.runtime.pipeline import LikelihoodPipeline
     from cosmosis.runtime.module import Module
@@ -134,7 +141,7 @@ def _make_cosmosis_config(config):
     Parameters
     ----------
     config: dict
-        Configuration dictionary of 'sampler' section
+        Configuration dictionary of 'sampler' section of yaml
 
     Returns
     -------
@@ -153,7 +160,7 @@ def _make_cosmosis_config(config):
 
     # Passive-aggressive error message
     if sampler_name == 'fisher':
-        raise ValueError("The Fisher matrix sampler " +
+        raise ValueError("The Fisher matrix sampler "
                          "does not work since the refactor - sorry.")
 
     # Make into a pair dictionary with the right cosmosis sections
@@ -184,7 +191,7 @@ def _make_cosmosis_values(params):
     Parameters
     ----------
     params: dict
-        Configuration dictionary of 'sampler' section and options
+        Configuration dictionary of 'parameters' section of input yaml
 
     Returns
     -------

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -30,11 +30,11 @@ def run_cosmosis(config, data):
       sampler - name of sampler to use, e.g. emcee, multinest, grid, ...
       output - name of file to save to
 
-
     Parameters
     ----------
     config : dict
         Configuration info, usually read directly from the YAML file
+
     data : dict
         The result of calling `firecrown.config.parse` on an input YAML
         config.
@@ -68,7 +68,6 @@ def _make_parallel_pool(cosmosis_config):
     ----------
     cosmosis_config: dict
         Sampler configuration section of the input
-
 
     Returns
     -------

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -125,7 +125,10 @@ def _make_cosmosis_pipeline(data, values, pool):
             pipeline = LikelihoodPipeline(load=False, values=values,
                                           priors=None)
 
+    # Flush now to print out the master node's setup stdout
+    # before printing the worker likelihoods
     sys.stdout.flush()
+
     # Set up a single cosmosis module, which will be the interface
     # file in the same directory as this one
     module = Module('firecrown', COSMOSIS_INTERFACE)
@@ -201,6 +204,7 @@ def _make_cosmosis_values(params):
     """
     from cosmosis.runtime.config import Inifile
 
+    # copy all the parameters into the cosmosis config structure
     values = {}
     for p, v in params.items():
         key = ('params', p)

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -10,7 +10,7 @@ THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
 COSMOSIS_INTERFACE = str(THIS_DIRECTORY.joinpath('interface.py'))
 
 
-def run(config, data):
+def run_cosmosis(config, data):
     """Run CosmoSIS on the problem.
 
     This requires the following parameters 'sampler' section

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -75,7 +75,7 @@ def _make_parallel_pool(cosmosis_config):
     if use_mpi:
         pool = MPIPool()
         if pool.size == 1:
-            print("Have mpi set to True but one process.")
+            print("Have mpi=True, but only running a single process.")
             print("I will ignore and run in serial mode.")
             pool = None
     else:

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -33,9 +33,9 @@ def run_cosmosis(config, data):
 
     # Extract the bits of the config file that
     # cosmosis wants
-    ini = _make_cosmosis_config(config['sampler'])
+    ini = _make_cosmosis_params(config['cosmosis'])
     values = _make_cosmosis_values(config['parameters'])
-    pool = _make_parallel_pool(config['sampler'])
+    pool = _make_parallel_pool(config['cosmosis'])
     pipeline = _make_cosmosis_pipeline(data, values, pool)
 
     # Actually run the thing
@@ -45,16 +45,16 @@ def run_cosmosis(config, data):
         pool.close()
 
 
-def _make_parallel_pool(config):
+def _make_parallel_pool(cosmosis_config):
     """ Set up a parallel process pool.
 
     Parameters
     ----------
 
-    config: dict
+    cosmosis_config: dict
         Sampler configuration section of the input
 
-    Will look for the 'mpi' command in the parallel section
+    Will look for the 'mpi' key in the input.
 
     Returns
     -------
@@ -70,7 +70,7 @@ def _make_parallel_pool(config):
     # on many systems, including, importantly, NERSC,
     # trying to import MPI when not running under the
     # MPI environment will cause a crash
-    use_mpi = config.get('mpi', False)
+    use_mpi = cosmosis_config.get('mpi', False)
 
     if use_mpi:
         pool = MPIPool()
@@ -138,27 +138,27 @@ def _make_cosmosis_pipeline(data, values, pool):
     return pipeline
 
 
-def _make_cosmosis_config(config):
+def _make_cosmosis_params(cosmosis_config):
     """ Extract a cosmosis configuration object from a config dict
 
     Parameters
     ----------
-    config: dict
-        Configuration dictionary of 'sampler' section of yaml
+    cosmosis_config: dict
+        Configuration dictionary of 'cosmosis' section of yaml
 
     Returns
     -------
 
-    cosmosis_config: Inifile
+    cosmosis_params: Inifile
         object to use to build cosmosis pipeline
     """
     from cosmosis.runtime.config import Inifile
 
     # Some general options
-    sampler_name = config['sampler']
-    output_file = config['output']
-    debug = config.get('debug', False)
-    quiet = config.get('quiet', False)
+    sampler_name = cosmosis_config['sampler']
+    output_file = cosmosis_config['output']
+    debug = cosmosis_config.get('debug', False)
+    quiet = cosmosis_config.get('quiet', False)
     root = ""  # Dummy value to stop cosmosis complaining
 
     # Passive-aggressive error message
@@ -176,16 +176,16 @@ def _make_cosmosis_config(config):
     }
 
     # Set all the sampler configuration options from the
-    # appropriate section of the config (e.g., the "grid"
+    # appropriate section of the cosmosis_config (e.g., the "grid"
     # section if using the grid sampler, etc.)
-    sampler_config = config.get(sampler_name, {})
+    sampler_config = cosmosis_config.get(sampler_name, {})
     for key, val in sampler_config.items():
         cosmosis_options[(sampler_name, key)] = str(val)
 
     # Convert into cosmosis Inifile format.
-    cosmosis_config = Inifile(None, override=cosmosis_options)
+    cosmosis_params = Inifile(None, override=cosmosis_options)
 
-    return cosmosis_config
+    return cosmosis_params
 
 
 def _make_cosmosis_values(params):

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -66,7 +66,7 @@ def _make_parallel_pool(config):
     from cosmosis.runtime.mpi_pool import MPIPool
 
     # There is a reason to make the user actively
-    # request to use MPI rather than just checking - 
+    # request to use MPI rather than just checking -
     # on many systems, including, importantly, NERSC,
     # trying to import MPI when not running under the
     # MPI environment will cause a crash
@@ -83,7 +83,6 @@ def _make_parallel_pool(config):
         print("Running in serial mode (one process).")
 
     return pool
-
 
 
 def _make_cosmosis_pipeline(data, values, pool):
@@ -112,10 +111,12 @@ def _make_cosmosis_pipeline(data, values, pool):
     # We avoid printing various bits of output info by silencing stdout on
     # worker nodes.
     if (pool is None) or pool.is_master():
-        pipeline = LikelihoodPipeline(load=False, values=values, priors=None)
+        pipeline = LikelihoodPipeline(load=False, values=values,
+                                      priors=None)
     else:
         with stdout_redirected():
-            pipeline = LikelihoodPipeline(load=False, values=values, priors=None)
+            pipeline = LikelihoodPipeline(load=False, values=values,
+                                          priors=None)
 
     sys.stdout.flush()
     # Set up a single cosmosis module, which will be the interface
@@ -125,7 +126,6 @@ def _make_cosmosis_pipeline(data, values, pool):
     pipeline.modules = [module]
 
     return pipeline
-
 
 
 def _make_cosmosis_config(config):
@@ -141,7 +141,6 @@ def _make_cosmosis_config(config):
 
     cosmosis_config: Inifile
         object to use to build cosmosis pipeline
-    
     """
     from cosmosis.runtime.config import Inifile
 
@@ -150,26 +149,27 @@ def _make_cosmosis_config(config):
     output_file = config['output']
     debug = config.get('debug', False)
     quiet = config.get('quiet', False)
-    root = "" # Dummy value to stop cosmosis complaining
+    root = ""  # Dummy value to stop cosmosis complaining
 
     # Passive-aggressive error message
     if sampler_name == 'fisher':
-        raise ValueError("The Fisher matrix sampler does not work since the refactor - sorry.")
+        raise ValueError("The Fisher matrix sampler " +
+                         "does not work since the refactor - sorry.")
 
     # Make into a pair dictionary with the right cosmosis sections
     cosmosis_options = {
-        ("runtime","root") : root,  
-        ("runtime","sampler") : sampler_name,
-        ("output","filename") : output_file,
-        ("pipeline","debug") : str(debug),
-        ("pipeline","quiet") : str(quiet),
+        ("runtime", "root"): root,
+        ("runtime", "sampler"): sampler_name,
+        ("output", "filename"): output_file,
+        ("pipeline", "debug"): str(debug),
+        ("pipeline", "quiet"): str(quiet),
     }
 
     # Set all the sampler configuration options from the
     # appropriate section of the config (e.g., the "grid"
     # section if using the grid sampler, etc.)
     sampler_config = config.get(sampler_name, {})
-    for key,val in sampler_config.items():
+    for key, val in sampler_config.items():
         cosmosis_options[(sampler_name, key)] = str(val)
 
     # Convert into cosmosis Inifile format.
@@ -191,14 +191,13 @@ def _make_cosmosis_values(params):
 
     cosmosis_values: Inifile
         object to use to build cosmosis parameter ranges/values
-    
     """
     from cosmosis.runtime.config import Inifile
 
     values = {}
-    for p,v in params.items():
-        key = ('params',p)
-        if isinstance(v,list):
+    for p, v in params.items():
+        key = ('params', p)
+        if isinstance(v, list):
             values[key] = ' '.join(str(x) for x in v)
         else:
             values[key] = str(v)
@@ -206,5 +205,3 @@ def _make_cosmosis_values(params):
     cosmosis_values = Inifile(None, override=values)
 
     return cosmosis_values
-
-

--- a/firecrown/cosmosis/run.py
+++ b/firecrown/cosmosis/run.py
@@ -27,7 +27,6 @@ def run_cosmosis(config, data):
     data : dict
         The result of calling `firecrown.config.parse` on an input YAML
         config.
-
     """
     from cosmosis.main import run_cosmosis
 
@@ -48,21 +47,19 @@ def run_cosmosis(config, data):
 def _make_parallel_pool(cosmosis_config):
     """ Set up a parallel process pool.
 
+    Will look for the 'mpi' key in the cosmosis_config.
+
     Parameters
     ----------
-
     cosmosis_config: dict
         Sampler configuration section of the input
 
-    Will look for the 'mpi' key in the input.
 
     Returns
     -------
-
     pool: CosmoSIS MPIPool object
         parallel process pool
     """
-
     from cosmosis.runtime.mpi_pool import MPIPool
 
     # There is a reason to make the user actively
@@ -90,7 +87,6 @@ def _make_cosmosis_pipeline(data, values, pool):
 
     Parameters
     ----------
-
     data: dict
         The data object parse'd from an input yaml file.
         This is passed as-is to the likelihood function
@@ -103,7 +99,6 @@ def _make_cosmosis_pipeline(data, values, pool):
 
     Returns
     -------
-
     pipeline: CosmoSIS pipeline objects
         Instantiated pipeline ready to run.
     """
@@ -148,7 +143,6 @@ def _make_cosmosis_params(cosmosis_config):
 
     Returns
     -------
-
     cosmosis_params: Inifile
         object to use to build cosmosis pipeline
     """
@@ -198,7 +192,6 @@ def _make_cosmosis_values(params):
 
     Returns
     -------
-
     cosmosis_values: Inifile
         object to use to build cosmosis parameter ranges/values
     """

--- a/firecrown/loglike.py
+++ b/firecrown/loglike.py
@@ -23,7 +23,7 @@ def compute_loglike(*, cosmo, data):
 
     analyses = list(
         set(list(data.keys())) -
-        set(['parameters', 'run_metadata', 'sampler']))
+        set(['parameters', 'run_metadata', 'cosmosis']))
     for analysis in analyses:
         _ll, _stats = data[analysis]['eval'](
             cosmo=cosmo,

--- a/firecrown/loglike.py
+++ b/firecrown/loglike.py
@@ -23,7 +23,7 @@ def compute_loglike(*, cosmo, data):
 
     analyses = list(
         set(list(data.keys())) -
-        set(['parameters', 'run_metadata', 'cosmosis']))
+        set(['parameters', 'cosmosis']))
     for analysis in analyses:
         _ll, _stats = data[analysis]['eval'](
             cosmo=cosmo,

--- a/firecrown/loglike.py
+++ b/firecrown/loglike.py
@@ -20,9 +20,10 @@ def compute_loglike(*, cosmo, data):
     """
     loglike = 0.0
     statistics = {}
+
     analyses = list(
         set(list(data.keys())) -
-        set(['parameters', 'run_metadata']))
+        set(['parameters', 'run_metadata', 'sampler']))
     for analysis in analyses:
         _ll, _stats = data[analysis]['eval'](
             cosmo=cosmo,

--- a/firecrown/parser.py
+++ b/firecrown/parser.py
@@ -27,7 +27,7 @@ def parse(filename):
 
     analyses = list(
         set(list(data.keys())) -
-        set(['parameters','sampler']))
+        set(['parameters', 'sampler']))
     for analysis in analyses:
         new_keys = {}
 

--- a/firecrown/parser.py
+++ b/firecrown/parser.py
@@ -27,7 +27,7 @@ def parse(filename):
 
     analyses = list(
         set(list(data.keys())) -
-        set(['parameters', 'sampler']))
+        set(['parameters', 'cosmosis']))
     for analysis in analyses:
         new_keys = {}
 

--- a/firecrown/parser.py
+++ b/firecrown/parser.py
@@ -27,7 +27,7 @@ def parse(filename):
 
     analyses = list(
         set(list(data.keys())) -
-        set(['parameters']))
+        set(['parameters','sampler']))
     for analysis in analyses:
         new_keys = {}
 

--- a/firecrown/tests/test_cosmosis.py
+++ b/firecrown/tests/test_cosmosis.py
@@ -1,0 +1,108 @@
+import pytest
+from ..cosmosis.run import _make_parallel_pool, _make_cosmosis_config
+from ..cosmosis.run import _make_cosmosis_values, _make_cosmosis_pipeline
+import yaml
+import numpy as np
+
+try:
+    import cosmosis
+except ImportError:
+    cosmosis = None
+
+requires_cosmosis = pytest.mark.skipif(cosmosis is None,
+                                       reason="cosmosis not installed")
+
+
+@pytest.fixture(scope="session")
+def tx_config(tmpdir_factory):
+    config_text = """
+parameters:
+  Omega_k: 0.0
+  Omega_c: [0.25, 0.27, 0.32]  # [min, start, max]
+  Omega_b: 0.045
+  h: 0.67
+  n_s: 0.96
+  A_s: [2.0e-9, 2.1e-9, 2.2e-9]
+  w0: -1.0
+  wa: 0.0
+
+  # lens bin zero
+  src0_delta_z: 0.0
+  src1_delta_z: 0.0
+
+
+sampler:
+  sampler: test
+  output: chain.txt
+  debug: True
+  quiet: False
+  mpi: False
+  # parameters for individual samplers:
+  test:
+    # pretending this sampler can take all these options
+    fatal_errors: True
+    walkers: 10
+    nsample: 20
+    nsample_dimension: 5
+    step_size: 0.02
+"""
+    config = yaml.load(config_text)
+    return config
+
+
+@requires_cosmosis
+def test_pool(tx_config):
+    pool = _make_parallel_pool(tx_config['sampler'])
+    assert pool is None or pool.size > 0
+    assert pool is None or isinstance(pool, cosmosis.runtime.mpi_pool.MPIPool)
+
+    # In general I'm wary of attempting tests that
+    # need MPI - bit of a minefield.
+    # Advice welcome.
+
+
+@requires_cosmosis
+def test_config(tx_config):
+    ini = _make_cosmosis_config(tx_config['sampler'])
+    assert isinstance(ini, cosmosis.runtime.config.Inifile)
+    assert ini.getint('test', 'walkers') == 10
+    assert np.isclose(ini.getfloat('test', 'step_size'), 0.02)
+    assert ini.getboolean('test', 'fatal_errors')
+    assert ini.get('runtime', 'sampler') == 'test'
+    assert ini.get('output', 'filename') == 'chain.txt'
+
+    with pytest.raises(ValueError):
+        assert ini.getboolean('test', 'walkers')
+
+
+@requires_cosmosis
+def test_values(tx_config):
+    values = _make_cosmosis_values(tx_config['parameters'])
+
+    assert values.getfloat('params', 'Omega_k') == 0
+    assert values.get('params', 'Omega_c').split() == ['0.25', '0.27', '0.32']
+
+    with pytest.raises(cosmosis.runtime.config.CosmosisConfigurationError):
+        assert values.getfloat('cosmological_parameters', 'Omega_k')
+
+
+@requires_cosmosis
+def test_pipeline(tx_config):
+    data = None
+    values = _make_cosmosis_values(tx_config['parameters'])
+    pool = None
+    pipeline = _make_cosmosis_pipeline(data, values, pool)
+
+    # check all params made it through
+    assert pipeline.nvaried == 2
+    assert pipeline.nfixed == 8
+
+    # check that parameter limits are right
+    assert np.allclose(pipeline.min_vector(), np.array([0.25, 2.0e-9]))
+    assert np.allclose(pipeline.min_vector(), np.array([0.25, 2.0e-9]))
+
+    # check params have correct names
+    assert pipeline.output_names() == ['params--omega_c', 'params--a_s']
+
+    # Check the modules list is set up
+    assert len(pipeline.modules) == 1

--- a/firecrown/tests/test_cosmosis.py
+++ b/firecrown/tests/test_cosmosis.py
@@ -1,5 +1,5 @@
 import pytest
-from ..cosmosis.run import _make_parallel_pool, _make_cosmosis_config
+from ..cosmosis.run import _make_parallel_pool, _make_cosmosis_params
 from ..cosmosis.run import _make_cosmosis_values, _make_cosmosis_pipeline
 import yaml
 import numpy as np
@@ -31,7 +31,7 @@ parameters:
   src1_delta_z: 0.0
 
 
-sampler:
+cosmosis:
   sampler: test
   output: chain.txt
   debug: True
@@ -52,7 +52,7 @@ sampler:
 
 @requires_cosmosis
 def test_pool(tx_config):
-    pool = _make_parallel_pool(tx_config['sampler'])
+    pool = _make_parallel_pool(tx_config['cosmosis'])
     assert pool is None or pool.size > 0
     assert pool is None or isinstance(pool, cosmosis.runtime.mpi_pool.MPIPool)
 
@@ -63,7 +63,7 @@ def test_pool(tx_config):
 
 @requires_cosmosis
 def test_config(tx_config):
-    ini = _make_cosmosis_config(tx_config['sampler'])
+    ini = _make_cosmosis_params(tx_config['cosmosis'])
     assert isinstance(ini, cosmosis.runtime.config.Inifile)
     assert ini.getint('test', 'walkers') == 10
     assert np.isclose(ini.getfloat('test', 'step_size'), 0.02)

--- a/firecrown/tests/test_cosmosis.py
+++ b/firecrown/tests/test_cosmosis.py
@@ -19,7 +19,10 @@ def tx_config(tmpdir_factory):
     config_text = """
 parameters:
   Omega_k: 0.0
-  Omega_c: [0.25, 0.27, 0.32]  # [min, start, max]
+  # Parameters varied with cosmosis
+  # need a min value, starting point, and max value,
+  # like so:
+  Omega_c: [0.25, 0.27, 0.32]
   Omega_b: 0.045
   h: 0.67
   n_s: 0.96

--- a/firecrown/tests/test_cosmosis.py
+++ b/firecrown/tests/test_cosmosis.py
@@ -99,7 +99,7 @@ def test_pipeline(tx_config):
 
     # check that parameter limits are right
     assert np.allclose(pipeline.min_vector(), np.array([0.25, 2.0e-9]))
-    assert np.allclose(pipeline.min_vector(), np.array([0.25, 2.0e-9]))
+    assert np.allclose(pipeline.max_vector(), np.array([0.32, 2.2e-9]))
 
     # check params have correct names
     assert pipeline.output_names() == ['params--omega_c', 'params--a_s']


### PR DESCRIPTION
This PR re-enables the interface of FireCrown to the CosmoSIS samplers.
Sampling with most of them will now work using `firecrown sample file.yaml`

Everything cosmosis-related is in the cosmosis subdirectory, and I've simplified it a bit since the previous version.  If you don't have cosmosis installed the other stuff will still work.

Also I changed from sigma_8 to A_s in the examples, since the latter is the official parameter of DESC.

On a separate note - we should disable flake8 in the CI.  It will put off too many potential contributors.

Closes #30