### PR TITLE
BUG make sure to convert to python scalars

### DIFF
--- a/firecrown/analysis/emcee_interface.py
+++ b/firecrown/analysis/emcee_interface.py
@@ -137,7 +137,7 @@ def run_emcee(config, data, *, parameters, n_steps,
         # compute the stats at the best point seen
         max_ind = np.argmax(chain['loglike'])
         for k in parameters:
-            data['parameters'][k] = chain[k][max_ind]
+            data['parameters'][k] = np.asscalar(chain[k][max_ind])
         cosmo = get_ccl_cosmology(data['parameters'])
         _, stats = compute_loglike(cosmo=cosmo, data=data)
 

--- a/firecrown/analysis/tests/test_emcee_interface.py
+++ b/firecrown/analysis/tests/test_emcee_interface.py
@@ -48,3 +48,4 @@ def test_run_emcee(n_walkers):
     assert np.abs((mn - 0.5) / sd) <= 1
     assert np.max(chain['emcee_walker']) == 9
     assert np.max(chain['mcmc_step']) == 999
+    assert type(data['parameters']['x']) == float


### PR DESCRIPTION
This PR makes sure the output from emcee is converted to a python scalar in the parameters so that the output YAML is nice to look at.