### PR TITLE
Add dependency in example README

### DIFF
--- a/examples/des_y1_3x2pt/README.md
+++ b/examples/des_y1_3x2pt/README.md
@@ -17,6 +17,12 @@ Finally, to run a chain, type
 $ firecrown run-emcee des_y1_3x2pt.yaml
 ```
 
+You might need to install the `schwimmbad` modeule if not already there. You can do this via pip:
+
+```bash
+pip install schwimmbad
+```
+
 ## Generating the `firecrown` Inputs
 
 Note, this code below only has to be run if you want to generate the firecrown


### PR DESCRIPTION
I needed to install `schwimmbad` to run this example. But it wasn't clear to me whether it's needed in other examples, and whether we could replace it by something else. Here are the schwimmbad docs: https://schwimmbad.readthedocs.io/en/latest/