### PR TITLE
Make all output files be saved in the same output_ directory

### DIFF
--- a/bin/firecrown
+++ b/bin/firecrown
@@ -4,7 +4,8 @@ import uuid
 import pprint
 import click
 import jinja2
-
+import pathlib
+import os
 
 import firecrown
 from firecrown.metadata import write_metadata
@@ -61,8 +62,14 @@ def run(action, config, output, verbose):
         sys.exit(0)
 
     analysis_id = uuid.uuid4().hex
+
+    # Expand and (if master) create output dir
+    output_path = pathlib.Path(os.path.expandvars(output)).expanduser()
+    output_dir = output_path / f'output_{analysis_id}'
+
     if print_or_run:
         print('analysis id:', analysis_id, flush=True)
+        output_dir.mkdir(exist_ok=False)
 
     _config, data = firecrown.parse(config)
     if verbose and (print_or_run):
@@ -80,7 +87,7 @@ def run(action, config, output, verbose):
             raise ValueError('You must have a `cosmosis` '
                              'configuration block to run `cosmosis`!')
 
-        firecrown.run_cosmosis(_config, data)
+        firecrown.run_cosmosis(_config, data, output_dir)
 
     elif action == 'run-emcee':
         if 'emcee' not in _config:
@@ -95,15 +102,15 @@ def run(action, config, output, verbose):
     # we associate a unique id with each analysis
     # let's write that out with some extra info
     if print_or_run:
-        write_metadata(analysis_id, output, config)
+        write_metadata(analysis_id, output_dir, config)
         if stats is not None:
             write_statistics(
                 analysis_id=analysis_id,
-                output_path=output,
+                output_path=output_dir,
                 data=data,
                 statistics=stats)
         if chain is not None:
-            write_analysis(analysis_id, output, chain)
+            write_analysis(analysis_id, output_dir, chain)
 
 
 if __name__ == '__main__':

--- a/examples/cosmicshear/cosmicshear.yaml
+++ b/examples/cosmicshear/cosmicshear.yaml
@@ -26,7 +26,6 @@ emcee:
 # through cosmosis
 cosmosis:
   sampler: fisher
-  output: chain.txt
   debug: True
   quiet: False
   mpi: False

--- a/examples/des_y1_3x2pt/des_y1_3x2pt.yaml
+++ b/examples/des_y1_3x2pt/des_y1_3x2pt.yaml
@@ -63,7 +63,6 @@ cosmosis:
   # the name of the sampler to use
   sampler: maxlike
   # the output chain file name
-  output: des-y1-3x2pt-maxlike.txt
   parameters:
     Omega_c: [0.1, 0.2545,  0.6]
     sigma8: [0.6,  0.801,  1.0]
@@ -87,7 +86,6 @@ cosmosis:
     live_points: 500
     efficiency: 0.3
     resume: True
-    multinest_outfile_root: des-y1-multinest
   # for computing a grid of models - works for up to about three dimensions
   # but quickly becomes untenable above that.
   grid:

--- a/firecrown/io.py
+++ b/firecrown/io.py
@@ -3,22 +3,21 @@ import pandas as pd
 import yaml
 
 
-def write_statistics(*, analysis_id, output_path, data, statistics):
+def write_statistics(*, analysis_id, output_dir, data, statistics):
     """Write statistics to an output path.
 
     Parameters
     ----------
     analysis_id : str
         A unique id for this analysis.
-    output_path : str
-        The path to which to write the run metdata.
+    output_dir : str or Path
+        The directory in which which to write the statistics.
     data : dict
         The output of `parse_config`.
     statistics : dict
         Dictionary containing the output `stats` for each analysis.
     """
-    _opth = os.path.expandvars(os.path.expanduser(output_path))
-    _odir = os.path.join(_opth, 'output_%s' % analysis_id, 'statistics')
+    _odir = os.path.join(output_dir, 'statistics')
     os.makedirs(_odir, exist_ok=True)
 
     analyses = list(

--- a/firecrown/metadata.py
+++ b/firecrown/metadata.py
@@ -8,15 +8,15 @@ import pyccl
 from ._version import __version__
 
 
-def write_metadata(analysis_id, output_path, config_file):
+def write_metadata(analysis_id, output_dir, config_file):
     """Write run metadata to an output path.
 
     Parameters
     ----------
     analysis_id : str
         A unique id for this analysis.
-    output_path : str
-        The path to which to write the run metdata.
+    output_dir : str or Path
+        The directory in which to write metadata
     config_file : str
         The path to the config file.
     """
@@ -27,10 +27,10 @@ def write_metadata(analysis_id, output_path, config_file):
         'firecrown_version': __version__,
         'pyccl_version': pyccl.__version__}
 
-    _opth = os.path.expandvars(os.path.expanduser(output_path))
-    _odir = os.path.join(_opth, 'output_%s' % metadata['analysis_id'])
-    os.makedirs(_odir)
+    # Copy configuration file into output
+    shutil.copyfile(config_file,
+                    os.path.join(output_dir, 'config.yaml'))
 
-    shutil.copyfile(config_file, os.path.join(_odir, 'config.yaml'))
-    with open(os.path.join(_odir, 'metadata.yaml'), 'w') as fp:
+    # Save any metadata
+    with open(os.path.join(output_dir, 'metadata.yaml'), 'w') as fp:
         yaml.dump(metadata, fp, default_flow_style=False)


### PR DESCRIPTION
Addresses #106 

This automatically sets all the cosmosis parameters that involve output paths, so that they will always go in the output directory.  The most obvious output is the chain file, but there are various other auxiliary outputs too that apply to some samplers.

Users are warned if they try to set a parameter which is overridden.

This also involved moving the creation of that output dir to the top level in the firecrown executable.  I also made it use the most up-to-date standard library approach for paths, pathlib.