### PR TITLE
ENH add ell or theta range for 2pt stats and other binning options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: install dependencies
           command: |
             if [ ! -d miniconda ]; then
-              curl -s https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
+              curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
               bash miniconda.sh -b -p miniconda
               rm -f miniconda.sh
 

--- a/firecrown/ccl/likelihoods/gaussian.py
+++ b/firecrown/ccl/likelihoods/gaussian.py
@@ -46,11 +46,7 @@ class ConstGaussianLogLike(LogLike):
         _sd = sacc_data.copy()
         inds = []
         for stat in self.data_vector:
-            inds.append(
-                _sd.indices(
-                    statistics[stat].sacc_data_type,
-                    statistics[stat].sacc_tracers)
-            )
+            inds.append(statistics[stat].sacc_inds.copy())
         inds = np.concatenate(inds, axis=0)
         cov = np.zeros((len(inds), len(inds)))
         for new_i, old_i in enumerate(inds):

--- a/firecrown/ccl/likelihoods/tdist.py
+++ b/firecrown/ccl/likelihoods/tdist.py
@@ -54,11 +54,7 @@ class TdistLogLike(LogLike):
         _sd = sacc_data.copy()
         inds = []
         for stat in self.data_vector:
-            inds.append(
-                _sd.indices(
-                    statistics[stat].sacc_data_type,
-                    statistics[stat].sacc_tracers)
-            )
+            inds.append(statistics[stat].sacc_inds.copy())
         inds = np.concatenate(inds, axis=0)
         cov = np.zeros((len(inds), len(inds)))
         for new_i, old_i in enumerate(inds):

--- a/firecrown/ccl/likelihoods/tests/conftest.py
+++ b/firecrown/ccl/likelihoods/tests/conftest.py
@@ -57,6 +57,8 @@ def likelihood_test_data():
             statistics[sname] = DummyThing()
             statistics[sname].sacc_data_type = 'galaxy_density_cl'
             statistics[sname].sacc_tracers = (trci, trcj)
+            statistics[sname].sacc_inds = sacc_data.indices(
+                statistics[sname].sacc_data_type, statistics[sname].sacc_tracers)
             theory[sname] = np.zeros(2)
             data[sname] = sacc_data.get_ell_cl('galaxy_density_cl', trci, trcj)[1]
             data_vector.append(sname)

--- a/firecrown/ccl/statistics/tests/test_two_point.py
+++ b/firecrown/ccl/statistics/tests/test_two_point.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import copy
 
 import sacc
 import pyccl as ccl
@@ -68,7 +69,10 @@ def test_two_point_smoke(kind, ell_for_xi, tmpdir):
         sacc_data.add_ell_cl(sacc_kind, 'sacc_src0', 'sacc_src5', ell, cell*2)
     else:
         theta = np.logspace(1, 2, 100)
-        ell = _ell_for_xi(**ELL_FOR_XI_DEFAULTS)
+        ell_for_xi_kws = copy.deepcopy(ELL_FOR_XI_DEFAULTS)
+        if ell_for_xi is not None:
+            ell_for_xi_kws.update(ell_for_xi)
+        ell = _ell_for_xi(**ell_for_xi_kws)
         cell = ccl.angular_cl(cosmo, *tracers, ell)
         xi = ccl.correlation(
             cosmo, ell, cell, theta / 60.0, corr_type=kind) * scale

--- a/firecrown/ccl/statistics/tests/test_two_point.py
+++ b/firecrown/ccl/statistics/tests/test_two_point.py
@@ -12,11 +12,13 @@ class DummySource(object):
     pass
 
 
+@pytest.mark.parametrize('ell_or_theta_max', [None, 80])
+@pytest.mark.parametrize('ell_or_theta_min', [None, 20])
 @pytest.mark.parametrize('ell_for_xi', [None, ELL_FOR_XI_DEFAULTS, {'mid': 100}])
 @pytest.mark.parametrize(
     'kind',
     ['cl',  'gg', 'gl', 'l+', 'l-'])
-def test_two_point_smoke(kind, ell_for_xi, tmpdir):
+def test_two_point_sacc(kind, ell_for_xi, ell_or_theta_min, ell_or_theta_max, tmpdir):
     sacc_data = sacc.Sacc()
 
     cosmo = ccl.Cosmology(
@@ -63,12 +65,14 @@ def test_two_point_smoke(kind, ell_for_xi, tmpdir):
     scale = np.prod([sources['src0'].scale_, sources['src1'].scale_])
     if kind == 'cl':
         ell = np.logspace(1, 3, 10)
+        ell_or_theta = ell
         cell = ccl.angular_cl(cosmo, *tracers, ell) * scale
         sacc_kind = 'galaxy_shear_cl_ee'
         sacc_data.add_ell_cl(sacc_kind, 'sacc_src0', 'sacc_src1', ell, cell)
         sacc_data.add_ell_cl(sacc_kind, 'sacc_src0', 'sacc_src5', ell, cell*2)
     else:
         theta = np.logspace(1, 2, 100)
+        ell_or_theta = theta
         ell_for_xi_kws = copy.deepcopy(ELL_FOR_XI_DEFAULTS)
         if ell_for_xi is not None:
             ell_for_xi_kws.update(ell_for_xi)
@@ -87,14 +91,41 @@ def test_two_point_smoke(kind, ell_for_xi, tmpdir):
         sacc_data.add_theta_xi(sacc_kind, 'sacc_src0', 'sacc_src1', theta, xi)
         sacc_data.add_theta_xi(sacc_kind, 'sacc_src0', 'sacc_src5', theta, xi*2)
 
+    if ell_or_theta_min is not None:
+        q = np.where(ell_or_theta >= ell_or_theta_min)
+        ell_or_theta = ell_or_theta[q]
+        if kind == 'cl':
+            cell = cell[q]
+        else:
+            xi = xi[q]
+
+    if ell_or_theta_max is not None:
+        q = np.where(ell_or_theta <= ell_or_theta_max)
+        ell_or_theta = ell_or_theta[q]
+        if kind == 'cl':
+            cell = cell[q]
+        else:
+            xi = xi[q]
+
     stat = TwoPointStatistic(
-        sacc_data_type=sacc_kind, sources=['src0', 'src1'], ell_for_xi=ell_for_xi)
+        sacc_data_type=sacc_kind,
+        sources=['src0', 'src1'],
+        ell_for_xi=ell_for_xi,
+        ell_or_theta_min=ell_or_theta_min,
+        ell_or_theta_max=ell_or_theta_max,
+    )
     stat.read(sacc_data, sources)
     stat.compute(cosmo, {}, sources, systematics=None)
 
     if ell_for_xi is not None:
         for key in ell_for_xi:
             assert ell_for_xi[key] == stat.ell_for_xi[key]
+
+    assert np.array_equal(stat.ell_or_theta_, ell_or_theta)
+    if ell_or_theta_min is not None:
+        assert np.all(stat.ell_or_theta_ >= ell_or_theta_min)
+    if ell_or_theta_max is not None:
+        assert np.all(stat.ell_or_theta_ <= ell_or_theta_max)
 
     assert stat.ccl_kind == kind
     assert np.allclose(stat.scale_, np.prod(np.arange(2) / 2.0 + 1.0))
@@ -104,6 +135,151 @@ def test_two_point_smoke(kind, ell_for_xi, tmpdir):
         assert np.allclose(stat.measured_statistic_, xi)
 
     assert np.allclose(stat.measured_statistic_, stat.predicted_statistic_)
+
+
+@pytest.mark.parametrize('binning', ['log', 'lin'])
+@pytest.mark.parametrize('ell_or_theta_max', [None, 80])
+@pytest.mark.parametrize('ell_or_theta_min', [None, 20])
+@pytest.mark.parametrize('ell_for_xi', [None, ELL_FOR_XI_DEFAULTS, {'mid': 100}])
+@pytest.mark.parametrize(
+    'kind',
+    ['cl',  'gg', 'gl', 'l+', 'l-'])
+def test_two_point_gen(
+    kind, ell_for_xi, ell_or_theta_min, ell_or_theta_max, binning, tmpdir
+):
+    sacc_data = sacc.Sacc()
+
+    cosmo = ccl.Cosmology(
+        Omega_c=0.27,
+        Omega_b=0.045,
+        Omega_k=0.0,
+        w0=-1.0,
+        wa=0.0,
+        sigma8=0.8,
+        n_s=0.96,
+        h=0.67)
+
+    sources = {}
+    for i, mn in enumerate([0.25, 0.75]):
+        sources['src%d' % i] = DummySource()
+        z = np.linspace(0, 2, 50)
+        dndz = np.exp(-0.5 * (z - mn)**2 / 0.25 / 0.25)
+
+        if ('g' in kind and i == 0) or kind == 'gg':
+            sources['src%d' % i].tracer_ = ccl.NumberCountsTracer(
+                cosmo,
+                has_rsd=False,
+                dndz=(z, dndz),
+                bias=(z, np.ones_like(z) * 2.0))
+        else:
+            sources['src%d' % i].tracer_ = ccl.WeakLensingTracer(
+                cosmo,
+                dndz=(z, dndz))
+
+        sources['src%d' % i].sacc_tracer = 'sacc_src%d' % i
+        sources['src%d' % i].scale_ = i / 2.0 + 1.0
+        sacc_data.add_tracer('NZ', 'sacc_src%d' % i, z, dndz)
+
+    # add extra data to make sure nothing weird is pulled back out
+    sources['src3'] = DummySource()
+    sources['src3'].tracer_ = ccl.WeakLensingTracer(cosmo, dndz=(z, dndz))
+    sources['src3'].sacc_tracer = 'sacc_src3'
+    sources['src3'].scale_ = 25.0
+    sacc_data.add_tracer('NZ', 'sacc_src3', z, dndz)
+    sacc_data.add_tracer('NZ', 'sacc_src5', z, dndz*2)
+
+    # compute the statistic
+    tracers = [sources['src0'].tracer_, sources['src1'].tracer_]
+    scale = np.prod([sources['src0'].scale_, sources['src1'].scale_])
+    if kind == 'cl':
+        ell = np.logspace(1, 2, 10) if binning == 'log' else np.linspace(10, 100, 10)
+        ell = (
+            np.sqrt(ell[1:] * ell[:-1])
+            if binning == 'log'
+            else (ell[1:] + ell[:-1])/2
+        )
+        ell_or_theta = ell
+        cell = ccl.angular_cl(cosmo, *tracers, ell) * scale
+        sacc_kind = 'galaxy_shear_cl_ee'
+    else:
+        theta = (
+            np.logspace(1, 2, 10)
+            if binning == 'log'
+            else np.linspace(10, 100, 10)
+        )
+        theta = (
+            np.sqrt(theta[1:] * theta[:-1])
+            if binning == 'log'
+            else (theta[1:] + theta[:-1])/2
+        )
+        ell_or_theta = theta
+        ell_for_xi_kws = copy.deepcopy(ELL_FOR_XI_DEFAULTS)
+        if ell_for_xi is not None:
+            ell_for_xi_kws.update(ell_for_xi)
+        ell = _ell_for_xi(**ell_for_xi_kws)
+        cell = ccl.angular_cl(cosmo, *tracers, ell)
+        xi = ccl.correlation(
+            cosmo, ell, cell, theta / 60.0, corr_type=kind) * scale
+        if kind == 'gg':
+            sacc_kind = 'galaxy_density_xi'
+        elif kind == 'gl':
+            sacc_kind = 'galaxy_shearDensity_xi_t'
+        elif kind == 'l+':
+            sacc_kind = 'galaxy_shear_xi_plus'
+        elif kind == 'l-':
+            sacc_kind = 'galaxy_shear_xi_minus'
+
+    stat = TwoPointStatistic(
+        sacc_data_type=sacc_kind,
+        sources=['src0', 'src1'],
+        ell_for_xi=ell_for_xi,
+        ell_or_theta_min=ell_or_theta_min,
+        ell_or_theta_max=ell_or_theta_max,
+        ell_or_theta={
+            'min': 10,
+            'max': 100,
+            'n': 9,
+            'binning': binning,
+        }
+    )
+
+    if ell_or_theta_min is not None:
+        q = np.where(ell_or_theta >= ell_or_theta_min)
+        ell_or_theta = ell_or_theta[q]
+        if kind == 'cl':
+            cell = cell[q]
+        else:
+            xi = xi[q]
+
+    if ell_or_theta_max is not None:
+        q = np.where(ell_or_theta <= ell_or_theta_max)
+        ell_or_theta = ell_or_theta[q]
+        if kind == 'cl':
+            cell = cell[q]
+        else:
+            xi = xi[q]
+
+    stat.read(sacc_data, sources)
+    stat.compute(cosmo, {}, sources, systematics=None)
+
+    if ell_for_xi is not None:
+        for key in ell_for_xi:
+            assert ell_for_xi[key] == stat.ell_for_xi[key]
+
+    assert np.array_equal(stat.ell_or_theta_, ell_or_theta)
+    if ell_or_theta_min is not None:
+        assert np.all(stat.ell_or_theta_ >= ell_or_theta_min)
+    if ell_or_theta_max is not None:
+        assert np.all(stat.ell_or_theta_ <= ell_or_theta_max)
+
+    assert stat.ccl_kind == kind
+    assert np.allclose(stat.scale_, np.prod(np.arange(2) / 2.0 + 1.0))
+    if kind == 'cl':
+        assert np.allclose(stat.predicted_statistic_, cell)
+    else:
+        assert np.allclose(stat.predicted_statistic_, xi)
+
+    assert np.allclose(stat.measured_statistic_, 0)
 
 
 def test_two_point_raises_bad_sacc_data_type():

--- a/firecrown/ccl/statistics/two_point.py
+++ b/firecrown/ccl/statistics/two_point.py
@@ -194,7 +194,7 @@ class TwoPointStatistic(Statistic):
         ):
             warnings.warn(
                 "Tracers '%s' have 2pt data and you have specified `ell_or_theta` "
-                "in the configuration. `ell_or_theta` is being ignored!",
+                "in the configuration. `ell_or_theta` is being ignored!" % tracers,
                 warnings.UserWarning,
                 stacklevel=2,
             )

--- a/firecrown/ccl/statistics/two_point.py
+++ b/firecrown/ccl/statistics/two_point.py
@@ -21,13 +21,13 @@ SACC_DATA_TYPE_TO_CCL_KIND = {
 ELL_FOR_XI_DEFAULTS = dict(min=2, mid=50, max=6e4, n_log=200)
 
 
-def _ell_for_xi(*, ell_min, ell_mid, ell_max, n_log):
+def _ell_for_xi(*, min, mid, max, n_log):
     """Build an array of ells to sample the power spectrum for real-space
     predictions.
     """
     return np.concatenate((
-        np.linspace(ell_min, ell_mid-1, ell_mid-ell_min),
-        np.logspace(np.log10(ell_mid), np.log10(ell_max), n_log)))
+        np.linspace(min, mid-1, mid-min),
+        np.logspace(np.log10(mid), np.log10(max), n_log)))
 
 
 @functools.lru_cache(maxsize=128)

--- a/firecrown/tests/test_integration_with_cuts.py
+++ b/firecrown/tests/test_integration_with_cuts.py
@@ -1,0 +1,249 @@
+import os
+import numpy as np
+import pytest
+
+import sacc
+import pyccl as ccl
+
+from ..parser import parse
+from ..loglike import compute_loglike
+from ..io import write_statistics
+
+
+@pytest.fixture(scope="session")
+def tx_data(tmpdir_factory):
+    tmpdir = str(tmpdir_factory.mktemp("data"))
+
+    sacc_data = sacc.Sacc()
+
+    cosmo = ccl.Cosmology(
+        Omega_c=0.27,
+        Omega_b=0.045,
+        Omega_k=0.0,
+        w0=-1.0,
+        wa=0.0,
+        sigma8=0.8,
+        n_s=0.96,
+        h=0.67,
+        transfer_function='eisenstein_hu')
+
+    seed = 42
+    rng = np.random.RandomState(seed=seed)
+    eps = 0.01
+
+    tracers = []
+    for i, mn in enumerate([0.25, 0.75]):
+        z = np.linspace(0, 2, 50)
+        dndz = np.exp(-0.5 * (z - mn)**2 / 0.25 / 0.25)
+
+        sacc_data.add_tracer('NZ', 'trc%d' % i, z, dndz)
+
+        tracers.append(ccl.WeakLensingTracer(
+            cosmo,
+            dndz=(z, dndz)))
+
+    ell_min = {}
+    ell_max = {}
+
+    dv = []
+    ndv = []
+    dv_orig = []
+    ndv_orig = []
+    inds = []
+    msks = []
+    for i in range(len(tracers)):
+        for j in range(i, len(tracers)):
+            ell = np.logspace(1, 4, 10)
+            pell = ccl.angular_cl(cosmo, tracers[i], tracers[j], ell)
+            npell = pell + rng.normal(size=pell.shape[0]) * eps * pell
+
+            # all of the data goes into the file
+            sacc_data.add_ell_cl(
+                'galaxy_shear_cl_ee', 'trc%d' % i, 'trc%d' % j, ell, npell)
+            dv_orig.append(pell)
+            ndv_orig.append(npell)
+            inds.append(np.ones_like(pell))
+            msk = np.ones_like(pell).astype(np.bool)
+
+            # but only some of it comes back out
+            if rng.uniform() < 0.5:
+                ell_min[(i, j)] = rng.uniform(10, 100)
+                msk &= (ell >= ell_min[(i, j)])
+            else:
+                ell_min[(i, j)] = None
+
+            if rng.uniform() < 0.5:
+                ell_max[(i, j)] = rng.uniform(1000, 10000)
+                msk &= (ell <= ell_max[(i, j)])
+            else:
+                ell_max[(i, j)] = None
+
+            if ell_min[(i, j)] is not None:
+                q = np.where(ell >= ell_min[(i, j)])
+                ell = ell[q]
+                pell = pell[q]
+                npell = npell[q]
+
+            if ell_max[(i, j)] is not None:
+                q = np.where(ell <= ell_max[(i, j)])
+                ell = ell[q]
+                pell = pell[q]
+                npell = npell[q]
+
+            msks.append(msk)
+
+            dv.append(pell)
+            ndv.append(npell)
+
+    # a fake covariance matrix
+    dv_orig = np.concatenate(dv_orig, axis=0)
+    ndv_orig = np.concatenate(ndv_orig, axis=0)
+    cov = np.zeros((dv_orig.shape[0], dv_orig.shape[0]))
+    for i in range(len(dv_orig)):
+        cov[i, i] = (eps * dv_orig[i]) ** 2
+    sacc_data.add_covariance(cov)
+
+    sacc_data.save_fits(os.path.join(tmpdir, 'sacc.fits'), overwrite=True)
+
+    # cut the cov mat
+    inds = np.concatenate(inds, axis=0)
+    inds = np.cumsum(inds) - 1
+    msks = np.where(np.concatenate(msks, axis=0))[0]
+    n_keep = msks.shape[0]
+    new_cov = np.zeros((n_keep, n_keep))
+    for i_new, i_old in enumerate(msks):
+        for j_new, j_old in enumerate(msks):
+            new_cov[i_new, j_new] = cov[i_old, j_old]
+
+    # compute loglike
+    dv = np.concatenate(dv, axis=0)
+    ndv = np.concatenate(ndv, axis=0)
+    cinv = np.linalg.inv(new_cov)
+    delta = ndv - dv
+    loglike = -0.5 * np.dot(delta, np.dot(cinv, delta))
+
+    config = """\
+parameters:
+  Omega_k: 0.0
+  Omega_c: 0.27
+  Omega_b: 0.045
+  h: 0.67
+  n_s: [0.9, 0.96, 1.0]
+  sigma8: 0.8
+  w0: -1.0
+  wa: 0.0
+  transfer_function: 'eisenstein_hu'
+
+  # lens bin zero
+  src0_delta_z: [-0.1, 0.0, 0.1]
+  src1_delta_z: 0.0
+
+two_point:
+  module: firecrown.ccl.two_point
+  sacc_data: {tmpdir}/sacc.fits
+  sources:
+    src0:
+      kind: WLSource
+      sacc_tracer: trc0
+      systematics:
+        - pz_delta_0
+
+    src1:
+      kind: WLSource
+      sacc_tracer: trc1
+      systematics:
+        - pz_delta_1
+
+  systematics:
+    pz_delta_0:
+      kind: PhotoZShiftBias
+      delta_z: src0_delta_z
+
+    pz_delta_1:
+      kind: PhotoZShiftBias
+      delta_z: src1_delta_z
+
+  likelihood:
+    kind: ConstGaussianLogLike
+    data_vector:
+      - cl_src0_src0
+      - cl_src0_src1
+      - cl_src1_src1
+
+  statistics:
+""".format(tmpdir=tmpdir)
+
+    for i in range(len(tracers)):
+        for j in range(i, len(tracers)):
+            config += """\
+    cl_src{i}_src{j}:
+      sources: ['src{i}', 'src{j}']
+      sacc_data_type: galaxy_shear_cl_ee
+""".format(i=i, j=j)
+
+            if ell_min[(i, j)] is not None:
+                config += "      ell_or_theta_min: {val}\n".format(val=ell_min[(i, j)])
+
+            if ell_max[(i, j)] is not None:
+                config += "      ell_or_theta_max: {val}\n".format(val=ell_max[(i, j)])
+
+    with open(os.path.join(tmpdir, 'config.yaml'), 'w') as fp:
+        fp.write(config)
+
+    return {
+        'cosmo': cosmo,
+        'tmpdir': tmpdir,
+        'loglike': loglike,
+        'config': config,
+        'cov': new_cov,
+        'inv_cov': cinv,
+    }
+
+
+def test_integration_with_cuts_smoke(tx_data):
+    tmpdir = tx_data['tmpdir']
+    cfg_path = os.path.join(tmpdir, 'config.yaml')
+
+    config, data = parse(cfg_path)
+    loglike, meas, pred, covs, inv_covs, stats = compute_loglike(
+        cosmo=tx_data['cosmo'],
+        data=data)
+
+    assert np.allclose(loglike["two_point"], tx_data['loglike'])
+
+    write_statistics(
+        output_dir=os.path.join(tmpdir, 'output_123'),
+        data=data,
+        statistics=stats,
+    )
+
+    opth = os.path.join(tmpdir, 'output_123', 'statistics', 'two_point')
+    orig_data = sacc.Sacc.load_fits(os.path.join(tmpdir, 'sacc.fits'))
+    meas_data = sacc.Sacc.load_fits(os.path.join(opth, 'sacc_measured.fits'))
+    pred_data = sacc.Sacc.load_fits(os.path.join(opth, 'sacc_predicted.fits'))
+
+    for trc_name in ['trc0', 'trc1']:
+        orig_tr = orig_data.get_tracer(trc_name)
+        meas_tr = meas_data.get_tracer(trc_name)
+        pred_tr = pred_data.get_tracer(trc_name)
+
+        assert np.allclose(orig_tr.z, meas_tr.z)
+        assert np.allclose(orig_tr.z, pred_tr.z)
+        assert np.allclose(orig_tr.nz, meas_tr.nz)
+        assert np.allclose(orig_tr.nz, pred_tr.nz)
+
+    meas_dv = []
+    pred_dv = []
+    for trs in [('trc0', 'trc0'), ('trc0', 'trc1'), ('trc1', 'trc1')]:
+        mell, mcl = meas_data.get_ell_cl('galaxy_shear_cl_ee', trs[0], trs[1])
+        pell, pcl = pred_data.get_ell_cl('galaxy_shear_cl_ee', trs[0], trs[1])
+
+        assert np.allclose(pell, mell)
+        assert not np.array_equal(mcl, pcl)
+        meas_dv.append(mcl)
+        pred_dv.append(pcl)
+
+    assert np.allclose(np.concatenate(meas_dv, axis=0), meas["two_point"])
+    assert np.allclose(np.concatenate(pred_dv, axis=0), pred["two_point"])
+    assert np.allclose(covs["two_point"], tx_data["cov"])
+    assert np.allclose(inv_covs["two_point"], tx_data["inv_cov"])


### PR DESCRIPTION
This PR adds bin limit and generation options for 2pt stats. The API is

```yaml
# these cut down any existing bins
ell_or_theta_min: 10
ell_or_theta_max: 100

# these would generate bins to be used
# the min or max options above get applied to these too
# any input SACC data always is used before this block,
# even if it is present
ell_or_theta:
  min: 10
  max: 1000
  n: 10
  binning: 'log'
```

These are extra options to any 2pt stat in the config file.

This PR also renames the old ell_min, etc options to a new block `ell_for_xi` which has keys `min`, `max`, `mid`, `n_log` matching the options in CCL.