### PR TITLE
Fix priors test

### DIFF
--- a/firecrown/tests/test_priors.py
+++ b/firecrown/tests/test_priors.py
@@ -16,9 +16,9 @@ def test_priors():
     loglike, ms, pd, cov, inv_cov, stats = compute_loglike(
         cosmo=None, parameters=parameters, data=data)
 
-    assert loglike == (
+    assert ((loglike - (
         -0.5 * ((0.3) / 1.0)**2 - 0.5 * np.log(2.0 * np.pi) +
-        -0.5 * ((-0.1 - 0.1) / 2.0)**2 - 0.5 * np.log(2.0 * np.pi) - np.log(2))
+        -0.5 * ((-0.1 - 0.1) / 2.0)**2 - 0.5 * np.log(2.0 * np.pi) - np.log(2)))/loglike < 1e-10)
     assert stats is None
     assert ms is None
     assert pd is None


### PR DESCRIPTION
I was having trouble with one of the tests in Firecrown. It was testing whether number a == number b. I set it so now it tests that the fractional difference is smaller than 1e-10. 