### PR TITLE
SN Updates

### DIFF
--- a/examples/srd_sn/README.md
+++ b/examples/srd_sn/README.md
@@ -1,0 +1,18 @@
+generate_sn_data.py : creates the sacc file output.
+
+For default execution,
+python generate_sn_data.py
+
+
+For user defined input files,
+3 arguments are passed
+
+SYNTAX:
+python generate_sn_data.py <PATH> <Hubble Diagram> <Covariance Matrix>
+
+EXAMPLE:
+python generate_sn_data.py ~/example data.txt sys.txt
+
+REQUIREMENTS:
+Both the files Hubble Diagram and Covariance Matrix should be in the same folder.
+The location of which is then passed as argument <PATH>

--- a/examples/srd_sn/generate_sn_data.py
+++ b/examples/srd_sn/generate_sn_data.py
@@ -5,55 +5,74 @@ import numpy as np
 import tarfile
 import urllib.request
 import datetime
+import sys
 
-dirname_year1 = "sndata/Y1_DDF_FOUNDATION"
-dirname_year10 = "sndata/Y10_DDF_WFD_FOUNDATION/"
-url = (
-    "https://zenodo.org/record/2662127/files/LSST_DESC_SRD_v1_release.tar.gz?download=1"
-)
 
-# check if file exists
-if os.path.exists(dirname_year1):
-    print("Y1 directory already downloaded")
-else:
-    print("Downloading full DESC SRD release files")
-    os.mkdir("sndata")
-    urllib.request.urlretrieve(url, "sndata/LSST_DESC_SRD_v1_release.tar.gz")
-    os.chdir("./sndata/")
-    print("Extracting full DESC SRD release files")
-    tf = tarfile.open("LSST_DESC_SRD_v1_release.tar.gz")
-    tf.extractall()
-    os.rename(
-        "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y1_DDF_FOUNDATION/",
-        "Y1_DDF_FOUNDATION",
-    )
-    os.rename(
-        "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y10_DDF_WFD_FOUNDATION/",
-        "Y10_DDF_WFD_FOUNDATION",
-    )
-    os.chdir("../../")
-    print("Done")
+S = Sacc()
 
-if os.path.exists(dirname_year10):
-    print("Y10 directory already downloaded")
-else:
-    print("Downloading full DESC SRD release files")
-    os.mkdir("sndata")
-    urllib.request.urlretrieve(url, "sndata/LSST_DESC_SRD_v1_release.tar.gz")
-    os.chdir("./sndata/")
-    print("Extracting full DESC SRD release files")
-    tf = tarfile.open("LSST_DESC_SRD_v1_release.tar.gz")
-    tf.extractall()
-    os.rename(
-        "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y1_DDF_FOUNDATION/",
-        "Y1_DDF_FOUNDATION",
+if len(sys.argv) == 4:
+    path  = sys.argv[1]
+    HD = sys.argv[2]
+    cov = sys.argv[3]
+    y1dat = np.loadtxt(path+"/"+HD, unpack=True)
+    y1cov = np.loadtxt(path+"/"+cov, unpack=True)
+    print("1. SUCESS")
+else :
+    dirname_year1 = "sndata/Y1_DDF_FOUNDATION"
+    dirname_year10 = "sndata/Y10_DDF_WFD_FOUNDATION/"
+    url = (
+        "https://zenodo.org/record/2662127/files/LSST_DESC_SRD_v1_release.tar.gz?download=1"
     )
-    os.rename(
-        "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y10_DDF_WFD_FOUNDATION/",
-        "Y10_DDF_WFD_FOUNDATION",
-    )
-    os.chdir("../../")
-    print("Done")
+    
+    # check if file exists
+    if os.path.exists(dirname_year1):
+        print("Y1 directory already downloaded")
+    else:
+        print("Downloading full DESC SRD release files")
+        os.mkdir("sndata")
+        urllib.request.urlretrieve(url, "sndata/LSST_DESC_SRD_v1_release.tar.gz")
+        os.chdir("./sndata/")
+        print("Extracting full DESC SRD release files")
+        tf = tarfile.open("LSST_DESC_SRD_v1_release.tar.gz")
+        tf.extractall()
+        os.rename(
+            "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y1_DDF_FOUNDATION/",
+            "Y1_DDF_FOUNDATION",
+        )
+        os.rename(
+            "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y10_DDF_WFD_FOUNDATION/",
+            "Y10_DDF_WFD_FOUNDATION",
+        )
+        os.chdir("../../")
+        print("Done")
+        
+        if os.path.exists(dirname_year10):
+            print("Y10 directory already downloaded")
+        else:
+            print("Downloading full DESC SRD release files")
+            os.mkdir("sndata")
+            urllib.request.urlretrieve(url, "sndata/LSST_DESC_SRD_v1_release.tar.gz")
+            os.chdir("./sndata/")
+            print("Extracting full DESC SRD release files")
+            tf = tarfile.open("LSST_DESC_SRD_v1_release.tar.gz")
+            tf.extractall()
+            os.rename(
+                "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y1_DDF_FOUNDATION/",
+                "Y1_DDF_FOUNDATION",
+            )
+            os.rename(
+                "LSST_DESC_SRD_v1_release/forecasting/SN/LikelihoodFiles/Y10_DDF_WFD_FOUNDATION/",
+                "Y10_DDF_WFD_FOUNDATION",
+            )
+            os.chdir("../../")
+            print("Done")
+
+            
+            # read in the Y1 data
+            y1dat = np.loadtxt("sndata/Y1_DDF_FOUNDATION/lcparam_Y1_DDF_1.0xFOUNDATION_noScatter.txt", unpack=True)
+            y1cov = np.loadtxt("sndata/Y1_DDF_FOUNDATION/sys_Y1_DDF_FOUNDATION_0.txt", unpack=True)
+            print("2. SUCESS")
+            
 
 #  set up the sacc data name for the astrophysical sources involved.
 sources = ["supernova"]
@@ -61,7 +80,7 @@ properties = ["distance"]
 
 # The statistc
 statistic = "mu"
-
+            
 # There is no futher specified needed here - everything is scalar.
 subtype = None
 sndata_type = sacc.build_data_type_name(sources, properties, statistic, subtype)
@@ -76,20 +95,12 @@ print(
     type_details.statistic,
     type_details.subtype,
 )
-
+            
 # Each DataPoint object contains:
-
 # a data type string
 # a series of strings listing which tracers apply to it
 # a value of the data point
 # a dictionary of tags, for example describing binning information
-
-S = Sacc()
-# read in the Y1 data
-y1dat = np.loadtxt(
-    "sndata/Y1_DDF_FOUNDATION/lcparam_Y1_DDF_1.0xFOUNDATION_noScatter.txt", unpack=True
-)
-y1cov = np.loadtxt("sndata/Y1_DDF_FOUNDATION/sys_Y1_DDF_FOUNDATION_0.txt", unpack=True)
 
 zhel = y1dat[2]  # redshift
 zcmb = y1dat[1]  # redshift

--- a/examples/srd_sn/sn_only.ini
+++ b/examples/srd_sn/sn_only.ini
@@ -1,0 +1,61 @@
+[runtime]
+sampler = emcee
+root = ${PWD}
+resume=T
+
+[default]
+fatal_errors = T
+
+[output]
+filename = ${FIRECROWN_DIR}/examples/srd_sn/output/sn_srd_snonly.txt
+format = text
+verbosity = debug 
+
+
+[pipeline]
+modules = consistency camb firecrown_likelihood 
+values = ${FIRECROWN_DIR}/examples/srd_sn/snonly_values.ini
+quiet = F
+debug = F
+timing = T
+
+[consistency]
+file = ${CSL_DIR}/utility/consistency/consistency_interface.py
+verbose = T
+
+[camb]
+file = ${CSL_DIR}/boltzmann/camb/camb_interface.py
+mode = background
+lmax = 2800          ;max ell to use for cmb calculation
+feedback=0         ;amount of output to print
+;AccuracyBoost=1.1 ;CAMB accuracy boost parameter
+;do_tensors = True   ;include tensor modes
+;do_lensing = true    ;lensing is required w/ Planck data
+;NonLinear = lens
+;zmax = 40.0
+use_ppf_w = T
+;matter_power_spectrum='linear'
+;;matter_power_lin_version = 3
+
+[firecrown_likelihood]
+;; Fix this to use an environment variable to find the files.
+;; Set FIRECROWN_DIR to the base of the firecrown installation (or build, if you havent
+;; installed it)
+;; this needs to be udpated for SN-specific analysis!
+file = ${FIRECROWN_DIR}/firecrown/connector/cosmosis/likelihood.py
+firecrown_config =${FIRECROWN_DIR}/examples/srd_sn/sn_srd.py
+require_nonlinear_pk=F
+
+
+[test]
+fatal_errors = T
+save_dir = sn_srd_output
+
+[metropolis]
+samples = 1000
+
+[emcee]
+walkers = 256
+samples = 500000
+nsteps = 5
+;start_points= ${FIRECROWN_DIR}/examples/srd_sn/output/sn_srd_snonly.txt 

--- a/examples/srd_sn/snonly_values.ini
+++ b/examples/srd_sn/snonly_values.ini
@@ -1,0 +1,25 @@
+; Parameters and data in CosmoSIS are organized into sections
+; so we can easily see what they mean.
+; There is only one section in this case, called cosmological_parameters
+
+[cosmological_parameters]
+; These are the only parameters being varied.
+omega_b = 0.04
+h0=0.682
+
+
+omega_m = 0.05  0.29352189787340449  0.8
+w = -2. -1. 0.0  
+wa = -1. 0.0 1.0 
+
+; The following parameters are set, but not varied.
+; omega_c is not set, because the consistency module sets it to omega_m - omega_b
+omega_k = 0.0
+tau = 0.08
+n_s = 0.971
+log1e10As = 3.0448
+sigma8_input = 0.801
+
+[firecrown_supernova_parameters]
+M=-20 -19.3 -19
+


### PR DESCRIPTION
          Update 1) `generate_sn_data.py` :  now the user can input any Hubble diagram and covariance matrix with inline arguments on the fly. Without needing to download the default DDF_10yrs data and associated covariance matrix etc and generate the `sacc` output file. 
           Update 2) Added README.md which defines how to input arguments for any custom SN input data files with `generate_sn_data.py` and generate their `sacc` file. 
           Update 3) Added a `sn_only.ini` file with a corresponding `snonly_values.ini` for an SN-only example script. 