### PR TITLE
Additional option to read DESC Formatted Hubble diagram data file

### DIFF
--- a/examples/srd_sn/README.md
+++ b/examples/srd_sn/README.md
@@ -4,15 +4,29 @@ This consists of a single systematic covariance matrix and
 the data vector which is the Hubble Diagram (HD) data.
 
 
-Hubble Diagram : The data format can be mostly zeros.
-The only columns that we actually use values from are:
+Hubble Diagram : Two types of file structure are allowed at
+the moment. 
+ 1. COSMOMC Format : The data format can be mostly zeros.
+ The only columns that we actually use values from are:
   zcmb zhel mb dmb
-(redshift (z) in CMB frame, redshift in heliocentric frame, magnitude, and magnitude error).
-Each row corresponds to one SN1A in case of unbinned HD or
-each redshift bin in case of z-binned HD.
+ (redshift (z) in CMB frame, redshift in heliocentric frame, magnitude, and magnitude error).
+ Each row corresponds to one SN1A in case of unbinned HD or
+ each redshift bin in case of z-binned HD.
 
-The Hubble Diagram data format should contain the following columns :
-#name zcmb zhel dz mb dmb x1 dx1 color dcolor 3rdvar d3rdvar cov_m_s cov_m_c cov_s_c set ra dec biascor
+ The Hubble Diagram data format should contain the following columns :
+ #name zcmb zhel dz mb dmb x1 dx1 color dcolor 3rdvar d3rdvar cov_m_s cov_m_c cov_s_c set ra dec biascor
+
+ 2.LSST DESC FORMAT : DESC is building its own Hubble diagram file format.
+ This file format is as follows :
+ # MU        = distance modulus corrected for bias and contamination
+ # MUERR     = stat-uncertainty on MU 
+ # MUERR_SYS = sqrt(COVSYS_DIAG) for 'ALL' sys (diagnostic)
+ # ISDATA_REAL: 0   # flag for cosmology fitter to choose blind option
+ #
+ VARNAMES: ROW zCMB zHEL MU MUERR MUERR_SYS
+ ROW: 1       0.04130 0.04130 36.31576  0.00966   0.00683
+
+Either of the above formats can be passed as argument for input Hubble Diagram.
 
 Covariance Matrix : The file format has the first line as an integer
 indicating the number of supernovae (N) and the subsequent

--- a/examples/srd_sn/generate_sn_data.py
+++ b/examples/srd_sn/generate_sn_data.py
@@ -2,6 +2,7 @@ import sacc
 from sacc import Sacc
 import os
 import numpy as np
+import pandas as pd
 import tarfile
 import urllib.request
 import datetime
@@ -10,12 +11,61 @@ import sys
 
 S = Sacc()
 
+
+def conversion(h):
+    """
+    CODE TO CONVERT THE NEW DESC HUBBLE DIAGRAM FILE STRUCTURE
+    SIMILAR TO COSMOMC STYLED INPUT HUBBLE DIAGRAM
+    FILE STRUCTURE
+    """
+    col = [
+        "#name",
+        "zcmb",
+        "zhel",
+        "dz",
+        "mb",
+        "dmb",
+        "x1",
+        "dx1",
+        "color",
+        "dcolor",
+        "3rdvar",
+        "d3rdvar",
+        "cov_m_s",
+        "cov_m_c",
+        "cov_s_c",
+        "set",
+        "ra",
+        "dec",
+        "biascor",
+    ]
+    h = pd.DataFrame(y1dat)
+    h.columns = h.iloc[0, :]
+    h = h.iloc[1:, 1:-1]
+    h = h.apply(pd.to_numeric)
+    h.MU -= 19.36
+    h.insert(3, "dz", np.zeros(np.shape(h)[0]))
+    row = np.shape(h)[0]
+    colu = 13
+    join = np.zeros((row, colu))
+    hh = pd.DataFrame(np.concatenate([h, join], axis=1))
+    hh.columns = col
+    h = hh
+    h["#name"] = np.linspace(0, np.shape(h)[0] - 1, np.shape(h)[0]).astype(int)
+    h = h.T
+    return h
+
+
 if len(sys.argv) == 4:
     path = sys.argv[1]
     HD = sys.argv[2]
     cov = sys.argv[3]
-    y1dat = np.loadtxt(path + "/" + HD, unpack=True)
-    y1cov = np.loadtxt(path + "/" + cov, unpack=True)
+    y1dat = np.loadtxt(open(path + "/" + HD, "rt"), comments="#", dtype=str)
+    y1cov = np.loadtxt(path + "/" + cov, comments="#", unpack=True)
+    if (y1dat[0][0][0]).isnumeric():
+        y1dat = np.array(y1dat).astype(float).T
+    else:
+        y1dat = conversion(y1dat)
     # print("1. SUCESS")
 else:
     dirname_year1 = "sndata/Y1_DDF_FOUNDATION"


### PR DESCRIPTION
User can now use two different styles of Hubble diagram (HD) as input. 

1. The default `cosmoMC` styled HD 
2. LSST DESC's HD with new file structure. 

Either of them can be now passed as argument by the user. 