### PR TITLE
Allow default parameter values

### DIFF
--- a/examples/des_y1_3x2pt/des_y1_3x2pt.py
+++ b/examples/des_y1_3x2pt/des_y1_3x2pt.py
@@ -14,7 +14,7 @@ import sacc
 # Sources
 
 
-lai_systematic = wl.LinearAlignmentSystematic(sacc_tracer="")
+lai_systematic = wl.LinearAlignmentSystematic(sacc_tracer="", alphag=None)
 
 """
     Creating sources, each one maps to a specific section of a SACC file. In

--- a/examples/srd_sn/sn_srd_values.ini
+++ b/examples/srd_sn/sn_srd_values.ini
@@ -21,6 +21,6 @@ w = -1.0
 wa = 0.0
 
 [firecrown_supernova_parameters]
-M=-20 -19.3 -19
+sn_ddf_sample_m=-20 -19.3 -19
 ; need to add in M to the likelihood
 

--- a/examples/srd_sn/sn_srd_values_planck_bao.ini
+++ b/examples/srd_sn/sn_srd_values_planck_bao.ini
@@ -14,4 +14,4 @@ log1e10As =  2.9   3.0448  3.1
 sigma8_input = 0.801
 
 [firecrown_supernova_parameters]
-M=-20 -19.3 -19
+sn_ddf_sample_m=-20 -19.3 -19

--- a/examples/srd_sn/snonly_values.ini
+++ b/examples/srd_sn/snonly_values.ini
@@ -19,5 +19,5 @@ log1e10As = 3.0448
 sigma8_input = 0.801
 
 [firecrown_supernova_parameters]
-M=-20 -19.3 -19
+sn_ddf_sample_m=-20 -19.3 -19
 

--- a/firecrown/connector/cosmosis/likelihood.py
+++ b/firecrown/connector/cosmosis/likelihood.py
@@ -126,6 +126,7 @@ class FirecrownLikelihood:
             if "firecrown" in section:
                 sec_dict = extract_section(sample, section)
                 firecrown_params = ParamsMap({**firecrown_params, **sec_dict})
+                firecrown_params.use_lower_case_keys(True)
         return firecrown_params
 
 

--- a/firecrown/likelihood/gauss_family/gauss_family.py
+++ b/firecrown/likelihood/gauss_family/gauss_family.py
@@ -116,7 +116,7 @@ class GaussFamily(Likelihood):
         subclasses."""
 
     @final
-    def required_parameters(self) -> RequiredParameters:
+    def _required_parameters(self) -> RequiredParameters:
         """Return a RequiredParameters object containing the information for
         this Updatable.
 
@@ -125,12 +125,12 @@ class GaussFamily(Likelihood):
 
         Derived classes must implement required_parameters_gaussian_family."""
         stats_rp = self.statistics.required_parameters()
-        stats_rp = self.required_parameters_gaussian_family() + stats_rp
+        stats_rp = self._required_parameters_gaussian_family() + stats_rp
 
         return stats_rp
 
     @abstractmethod
-    def required_parameters_gaussian_family(self):
+    def _required_parameters_gaussian_family(self):
         """Required parameters for GaussFamily subclasses."""
 
     @abstractmethod

--- a/firecrown/likelihood/gauss_family/gaussian.py
+++ b/firecrown/likelihood/gauss_family/gaussian.py
@@ -33,7 +33,7 @@ class ConstGaussian(GaussFamily):
         pass
 
     @final
-    def required_parameters_gaussian_family(self):
+    def _required_parameters_gaussian_family(self):
         return RequiredParameters([])
 
     @final

--- a/firecrown/likelihood/gauss_family/statistic/source/source.py
+++ b/firecrown/likelihood/gauss_family/statistic/source/source.py
@@ -27,8 +27,6 @@ class Source(Updatable):
 
     Parameters
     ----------
-    scale : 1.0, optional
-        The default scale for this source.
     systematics : list of str, optional
         A list of the source-level systematics to apply to the source. The
         default of `None` implies no systematics.

--- a/firecrown/likelihood/gauss_family/statistic/source/weak_lensing.py
+++ b/firecrown/likelihood/gauss_family/statistic/source/weak_lensing.py
@@ -17,7 +17,6 @@ from ..... import parameters
 from .....parameters import (
     ParamsMap,
     RequiredParameters,
-    parameter_get_full_name,
     DerivedParameterCollection,
 )
 from .....updatable import UpdatableCollection
@@ -50,14 +49,7 @@ class MultiplicativeShearBias(WeakLensingSystematic):
 
     This systematic adjusts the `scale_` of a source by `(1 + m)`.
 
-    Parameters
-    ----------
-    mult_bias : str
-       The name of the multiplicative bias parameter.
     """
-
-    params_names = ["mult_bias"]
-    m: float
 
     def __init__(self, sacc_tracer: str):
         """Create a MultiplicativeShearBias object that uses the named tracer.
@@ -67,14 +59,14 @@ class MultiplicativeShearBias(WeakLensingSystematic):
         """
         super().__init__()
 
+        self.mult_bias = parameters.create()
         self.sacc_tracer = sacc_tracer
 
     @final
     def _update(self, params: ParamsMap):
-        """Read the corresponding named tracer from the given collection of
-        parameters."""
-        # pylint: disable-next=invalid-name
-        self.m = params.get_from_prefix_param(self.sacc_tracer, "mult_bias")
+        """Perform any updates necessary after the parameters have being updated.
+
+        This implementation has nothing to do."""
 
     @final
     def _reset(self) -> None:
@@ -82,11 +74,8 @@ class MultiplicativeShearBias(WeakLensingSystematic):
 
         This implementation has nothing to do."""
 
-    @final
-    def required_parameters(self) -> RequiredParameters:
-        return RequiredParameters(
-            [parameter_get_full_name(self.sacc_tracer, pn) for pn in self.params_names]
-        )
+    def _required_parameters(self) -> RequiredParameters:
+        return RequiredParameters([])
 
     @final
     def _get_derived_parameters(self) -> DerivedParameterCollection:
@@ -105,7 +94,7 @@ class MultiplicativeShearBias(WeakLensingSystematic):
         """
 
         return WeakLensingArgs(
-            scale=tracer_arg.scale * (1.0 + self.m),
+            scale=tracer_arg.scale * (1.0 + self.mult_bias),
             z=tracer_arg.z,
             dndz=tracer_arg.dndz,
             ia_bias=tracer_arg.ia_bias,
@@ -118,18 +107,10 @@ class LinearAlignmentSystematic(WeakLensingSystematic):
     This systematic adds a linear intrinsic alignment model systematic
     which varies with redshift and the growth function.
 
-
-
     Methods
     -------
     apply : apply the systematic to a source
     """
-
-    params_names = ["ia_bias", "alphaz", "alphag", "z_piv"]
-    ia_bias: float
-    alphaz: float
-    alphag: float
-    z_piv: float
 
     def __init__(self, sacc_tracer: Optional[str] = None, alphag=1.0):
         """Create a LinearAlignmentSystematic object, using the specified
@@ -157,13 +138,19 @@ class LinearAlignmentSystematic(WeakLensingSystematic):
 
     @final
     def _update(self, params: ParamsMap):
-        pass
+        """Perform any updates necessary after the parameters have being updated.
+
+        This implementation has nothing to do."""
 
     @final
     def _reset(self) -> None:
         """Reset this systematic.
 
         This implementation has nothing to do."""
+
+    @final
+    def _required_parameters(self) -> RequiredParameters:
+        return RequiredParameters([])
 
     @final
     def _get_derived_parameters(self) -> DerivedParameterCollection:
@@ -175,10 +162,9 @@ class LinearAlignmentSystematic(WeakLensingSystematic):
         """Return a new linear alignment systematic, based on the given
         tracer_arg, in the context of the given cosmology."""
 
-        alphag = self.alphag
         pref = ((1.0 + tracer_arg.z) / (1.0 + self.z_piv)) ** self.alphaz
         pref *= pyccl.growth_factor(cosmo, 1.0 / (1.0 + tracer_arg.z)) ** (
-            alphag - 1.0
+            self.alphag - 1.0
         )
 
         ia_bias_array = pref * self.ia_bias
@@ -197,27 +183,25 @@ class PhotoZShift(WeakLensingSystematic):
     This systematic shifts the photo-z distribution by some amount `delta_z`.
     """
 
-    params_names = ["delta_z"]
-    delta_z: float
-
     def __init__(self, sacc_tracer: str):
         super().__init__()
 
+        self.delta_z = parameters.create()
         self.sacc_tracer = sacc_tracer
 
     @final
     def _update(self, params: ParamsMap):
-        self.delta_z = params.get_from_prefix_param(self.sacc_tracer, "delta_z")
+        """Perform any updates necessary after the parameters have being updated.
+
+        This implementation has nothing to do."""
 
     @final
     def _reset(self) -> None:
         pass
 
     @final
-    def required_parameters(self) -> RequiredParameters:
-        return RequiredParameters(
-            [parameter_get_full_name(self.sacc_tracer, pn) for pn in self.params_names]
-        )
+    def _required_parameters(self) -> RequiredParameters:
+        return RequiredParameters([])
 
     @final
     def _get_derived_parameters(self) -> DerivedParameterCollection:
@@ -277,7 +261,7 @@ class WeakLensing(Source):
         self.systematics.reset()
 
     @final
-    def required_parameters(self) -> RequiredParameters:
+    def _required_parameters(self) -> RequiredParameters:
         return self.systematics.required_parameters()
 
     @final

--- a/firecrown/likelihood/gauss_family/statistic/source/weak_lensing.py
+++ b/firecrown/likelihood/gauss_family/statistic/source/weak_lensing.py
@@ -153,7 +153,9 @@ class LinearAlignmentSystematic(WeakLensingSystematic):
     def _update(self, params: ParamsMap):
         self.ia_bias = params.get_from_prefix_param(self.sacc_tracer, "ia_bias")
         self.alphaz = params.get_from_prefix_param(self.sacc_tracer, "alphaz")
-        self.alphag = params.get_from_prefix_param(self.sacc_tracer, "alphag")
+        self.alphag = params.get_from_prefix_param(
+            self.sacc_tracer, "alphag", default=1.0
+        )
         self.z_piv = params.get_from_prefix_param(self.sacc_tracer, "z_piv")
 
     @final

--- a/firecrown/likelihood/gauss_family/statistic/supernova.py
+++ b/firecrown/likelihood/gauss_family/statistic/supernova.py
@@ -10,6 +10,7 @@ import pyccl
 import sacc
 
 from .statistic import Statistic
+from .... import parameters
 from ....parameters import ParamsMap, RequiredParameters, DerivedParameterCollection
 
 
@@ -24,7 +25,7 @@ class Supernova(Statistic):
         self.sacc_tracer = sacc_tracer
         self.data_vector = None
         self.a: Optional[np.ndarray] = None  # pylint: disable-msg=invalid-name
-        self.M = None  # pylint: disable-msg=invalid-name
+        self.M = parameters.create()  # pylint: disable-msg=invalid-name
 
     def read(self, sacc_data: sacc.Sacc):
         """Read the data for this statistic from the SACC file."""
@@ -36,24 +37,23 @@ class Supernova(Statistic):
         z = np.array([dp.get_tag("z") for dp in data_points])
         self.a = 1.0 / (1.0 + z)
         self.data_vector = np.array([dp.value for dp in data_points])
-        self.sacc_inds = list(range(0, len(self.data_vector)))
+        self.sacc_inds = list(
+            range(0, len(self.data_vector))
+        )  # pylint: disable-msg=invalid-name
 
     @final
     def _update(self, params: ParamsMap):
-        self.M = params["m"]  # CosmoSIS makes everything lowercase
+        """Perform any updates necessary after the parameters have being updated.
+
+        This implementation has nothing to do."""
 
     @final
     def _reset(self):
         pass
 
     @final
-    def required_parameters(self) -> RequiredParameters:
-        """Return a RequiredParameters object containing the information for this
-        statistic.
-
-        The only required parameter is`m`.
-        """
-        return RequiredParameters(["m"])
+    def _required_parameters(self) -> RequiredParameters:
+        return RequiredParameters([])
 
     @final
     def _get_derived_parameters(self) -> DerivedParameterCollection:

--- a/firecrown/likelihood/gauss_family/statistic/two_point.py
+++ b/firecrown/likelihood/gauss_family/statistic/two_point.py
@@ -195,7 +195,7 @@ class TwoPoint(Statistic):
         self.source1.reset()
 
     @final
-    def required_parameters(self) -> RequiredParameters:
+    def _required_parameters(self) -> RequiredParameters:
         return self.source0.required_parameters() + self.source1.required_parameters()
 
     @final

--- a/firecrown/likelihood/gauss_family/student_t.py
+++ b/firecrown/likelihood/gauss_family/student_t.py
@@ -3,7 +3,7 @@
 """
 
 from __future__ import annotations
-from typing import List, final
+from typing import List, Optional, final
 
 import numpy as np
 
@@ -11,6 +11,7 @@ import pyccl
 
 from .gauss_family import GaussFamily
 from .statistic.statistic import Statistic
+from ... import parameters
 from ...parameters import ParamsMap, RequiredParameters, DerivedParameterCollection
 
 
@@ -26,9 +27,9 @@ class StudentT(GaussFamily):
     :param nu: The Student-t $\\nu$ parameter
     """
 
-    def __init__(self, statistics: List[Statistic], nu: float):
+    def __init__(self, statistics: List[Statistic], nu: Optional[float]):
         super().__init__(statistics)
-        self.nu = nu  # pylint: disable-msg=C0103
+        self.nu = parameters.create(nu)  # pylint: disable-msg=C0103
 
     def compute_loglike(self, cosmo: pyccl.Cosmology):
         """Compute the log-likelihood.
@@ -48,7 +49,7 @@ class StudentT(GaussFamily):
         pass
 
     @final
-    def required_parameters_gaussian_family(self):
+    def _required_parameters_gaussian_family(self):
         return RequiredParameters([])
 
     @final

--- a/firecrown/parameters.py
+++ b/firecrown/parameters.py
@@ -37,9 +37,7 @@ class ParamsMap(Dict[str, float]):
     with square brackets like x[].
     """
 
-    def get_from_prefix_param(
-        self, prefix: Optional[str], param: str
-    ) -> float:
+    def get_from_prefix_param(self, prefix: Optional[str], param: str) -> float:
         """Return the parameter identified by the optional prefix and parameter name.
 
 

--- a/firecrown/parameters.py
+++ b/firecrown/parameters.py
@@ -37,6 +37,13 @@ class ParamsMap(Dict[str, float]):
     with square brackets like x[].
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lower_case: bool = False
+
+    def use_lower_case_keys(self, enable: bool):
+        self.lower_case = enable
+
     def get_from_prefix_param(self, prefix: Optional[str], param: str) -> float:
         """Return the parameter identified by the optional prefix and parameter name.
 
@@ -45,7 +52,10 @@ class ParamsMap(Dict[str, float]):
         Raises a KeyError if the parameter is not found.
         """
         fullname = parameter_get_full_name(prefix, param)
+        if self.lower_case:
+            fullname = fullname.lower()
 
+        print (f"{fullname} and {self.keys()}")
         if fullname in self.keys():
             return self[fullname]
         raise KeyError(f"Prefix `{prefix}`, key `{param}' not found.")
@@ -204,8 +214,7 @@ class DerivedParameterCollection:
                 f"RequiredParameter named {required_parameter_full_name}"
                 f" is already present in the collection"
             )
-        else:
-            self.derived_parameters[required_parameter_full_name] = derived_parameter
+        self.derived_parameters[required_parameter_full_name] = derived_parameter
 
     def get_derived_list(self) -> List[DerivedParameter]:
         """Implement lazy iteration through the contained parameter names."""
@@ -246,5 +255,4 @@ class InternalParameter:
 def create(value: Optional[float] = None):
     if value is None:
         return SamplerParameter()
-    else:
-        return InternalParameter(value)
+    return InternalParameter(value)

--- a/firecrown/parameters.py
+++ b/firecrown/parameters.py
@@ -37,7 +37,9 @@ class ParamsMap(Dict[str, float]):
     with square brackets like x[].
     """
 
-    def get_from_prefix_param(self, prefix: Optional[str], param: str) -> float:
+    def get_from_prefix_param(
+        self, prefix: Optional[str], param: str, default: Optional[float] = None
+    ) -> float:
         """Return the parameter identified by the optional prefix and parameter name.
 
 
@@ -48,6 +50,8 @@ class ParamsMap(Dict[str, float]):
 
         if fullname in self.keys():
             return self[fullname]
+        elif default is not None:
+            return default
         raise KeyError(f"Prefix `{prefix}`, key `{param}' not found.")
 
 

--- a/firecrown/parameters.py
+++ b/firecrown/parameters.py
@@ -38,7 +38,7 @@ class ParamsMap(Dict[str, float]):
     """
 
     def get_from_prefix_param(
-        self, prefix: Optional[str], param: str, default: Optional[float] = None
+        self, prefix: Optional[str], param: str
     ) -> float:
         """Return the parameter identified by the optional prefix and parameter name.
 
@@ -50,8 +50,6 @@ class ParamsMap(Dict[str, float]):
 
         if fullname in self.keys():
             return self[fullname]
-        elif default is not None:
-            return default
         raise KeyError(f"Prefix `{prefix}`, key `{param}' not found.")
 
 
@@ -215,3 +213,40 @@ class DerivedParameterCollection:
         """Implement lazy iteration through the contained parameter names."""
 
         return list(self.derived_parameters.values())
+
+
+class SamplerParameter:
+    """Class to represent a sampler defined parameter."""
+
+    def __init__(self):
+        """Creates a new SamplerParameter instance that represents a parameter
+        having its value defined by the sampler."""
+        self.value = None
+
+    def set_value(self, value: float):
+        self.value = value
+
+    def get_value(self) -> float:
+        return self.value
+
+
+class InternalParameter:
+    """Class to represent an internally defined parameter."""
+
+    def __init__(self, value: float):
+        """Creates a new InternalParameter instance that represents an
+        internal parameter with its value defined by value."""
+        self.value = value
+
+    def set_value(self, value: float):
+        self.value = value
+
+    def get_value(self) -> float:
+        return self.value
+
+
+def create(value: Optional[float] = None):
+    if value is None:
+        return SamplerParameter()
+    else:
+        return InternalParameter(value)

--- a/firecrown/parameters.py
+++ b/firecrown/parameters.py
@@ -55,7 +55,7 @@ class ParamsMap(Dict[str, float]):
         if self.lower_case:
             fullname = fullname.lower()
 
-        print (f"{fullname} and {self.keys()}")
+        print(f"{fullname} and {self.keys()}")
         if fullname in self.keys():
             return self[fullname]
         raise KeyError(f"Prefix `{prefix}`, key `{param}' not found.")

--- a/firecrown/parameters.py
+++ b/firecrown/parameters.py
@@ -55,7 +55,6 @@ class ParamsMap(Dict[str, float]):
         if self.lower_case:
             fullname = fullname.lower()
 
-        print(f"{fullname} and {self.keys()}")
         if fullname in self.keys():
             return self[fullname]
         raise KeyError(f"Prefix `{prefix}`, key `{param}' not found.")

--- a/firecrown/updatable.py
+++ b/firecrown/updatable.py
@@ -50,15 +50,13 @@ class Updatable(ABC):
         if isinstance(value, SamplerParameter):
             if key in self._sampler_parameters or hasattr(self, key):
                 raise ValueError(f"attribute {key} already set to the object")
-            else:
-                self._sampler_parameters[key] = value
-                super().__setattr__(key, None)
+            self._sampler_parameters[key] = value
+            super().__setattr__(key, None)
         elif isinstance(value, InternalParameter):
             if key in self._internal_parameters or hasattr(self, key):
                 raise ValueError(f"attribute {key} already set to the object")
-            else:
-                self._internal_parameters[key] = value
-                super().__setattr__(key, value.get_value())
+            self._internal_parameters[key] = value
+            super().__setattr__(key, value.get_value())
         else:
             super().__setattr__(key, value)
 
@@ -220,8 +218,7 @@ class UpdatableCollection(UserList):
                 has_any_derived = True
         if has_any_derived:
             return derived_parameters
-        else:
-            return None
+        return None
 
     def append(self, item: Updatable) -> None:
         """Append the given item to self.

--- a/firecrown/updatable.py
+++ b/firecrown/updatable.py
@@ -50,14 +50,16 @@ class Updatable(ABC):
         if isinstance(value, SamplerParameter):
             if key in self._sampler_parameters or hasattr(self, key):
                 raise ValueError(
-                    f"attribute {key} already set in {self} from a parameter read from the sampler"
+                    f"attribute {key} already set in {self} "
+                    f"from a parameter read from the sampler"
                 )
             self._sampler_parameters[key] = value
             super().__setattr__(key, None)
         elif isinstance(value, InternalParameter):
             if key in self._internal_parameters or hasattr(self, key):
                 raise ValueError(
-                    f"attribute {key} already set in {self} from a parameter supplied in the likelihood factory code"
+                    f"attribute {key} already set in {self} "
+                    f"from a parameter supplied in the likelihood factory code"
                 )
             self._internal_parameters[key] = value
             super().__setattr__(key, value.get_value())

--- a/firecrown/updatable.py
+++ b/firecrown/updatable.py
@@ -106,20 +106,31 @@ class Updatable(ABC):
         The base class implementation does nothing.
         """
 
+    @final
     def required_parameters(self) -> RequiredParameters:  # pragma: no cover
+        """Return a RequiredParameters object containing the information for
+        all parameters defined in the implementing class, any additional
+        parameter
+        """
+
+        sampler_parameters = RequiredParameters(
+            [
+                parameter_get_full_name(self.sacc_tracer, parameter)
+                for parameter in self._sampler_parameters
+            ]
+        )
+        additional_parameters = self._required_parameters()
+
+        return sampler_parameters + additional_parameters
+
+    @abstractmethod
+    def _required_parameters(self) -> RequiredParameters:  # pragma: no cover
         """Return a RequiredParameters object containing the information for
         this Updatable. This method must be overridden by concrete classes.
 
         The base class implementation returns a list with all SamplerParameter
         objects properties.
         """
-
-        return RequiredParameters(
-            [
-                parameter_get_full_name(self.sacc_tracer, parameter)
-                for parameter in self._sampler_parameters
-            ]
-        )
 
     @final
     def get_derived_parameters(

--- a/firecrown/updatable.py
+++ b/firecrown/updatable.py
@@ -49,12 +49,16 @@ class Updatable(ABC):
     def __setattr__(self, key, value):
         if isinstance(value, SamplerParameter):
             if key in self._sampler_parameters or hasattr(self, key):
-                raise ValueError(f"attribute {key} already set to the object")
+                raise ValueError(
+                    f"attribute {key} already set in {self} from a parameter read from the sampler"
+                )
             self._sampler_parameters[key] = value
             super().__setattr__(key, None)
         elif isinstance(value, InternalParameter):
             if key in self._internal_parameters or hasattr(self, key):
-                raise ValueError(f"attribute {key} already set to the object")
+                raise ValueError(
+                    f"attribute {key} already set in {self} from a parameter supplied in the likelihood factory code"
+                )
             self._internal_parameters[key] = value
             super().__setattr__(key, value.get_value())
         else:

--- a/tests/likelihood/lkdir/lkmodule.py
+++ b/tests/likelihood/lkdir/lkmodule.py
@@ -22,7 +22,7 @@ class EmptyLikelihood(Likelihood):
     def _reset(self) -> None:
         pass
 
-    def required_parameters(self):
+    def _required_parameters(self):
         return RequiredParameters([])
 
     def _get_derived_parameters(self) -> DerivedParameterCollection:

--- a/tests/test_updatable.py
+++ b/tests/test_updatable.py
@@ -1,5 +1,6 @@
 import pytest
 from firecrown.updatable import Updatable, UpdatableCollection
+from firecrown import parameters
 from firecrown.parameters import (
     RequiredParameters,
     ParamsMap,
@@ -10,7 +11,7 @@ from firecrown.parameters import (
 class Missing_update(Updatable):
     """A type that is abstract because it does not implement _update."""
 
-    def required_parameters(self):  # pragma: no cover
+    def _required_parameters(self):  # pragma: no cover
         pass
 
     def _reset(self) -> None:
@@ -26,7 +27,7 @@ class Missing_reset(Updatable):
     def _update(self, params):  # pragma: no cover
         pass
 
-    def required_parameters(self):  # pragma: no cover
+    def _required_parameters(self):  # pragma: no cover
         pass
 
     def _get_derived_parameters(self) -> DerivedParameterCollection:
@@ -53,16 +54,16 @@ class MinimalUpdatable(Updatable):
         """Initialize object with defaulted value."""
         super().__init__()
 
-        self.a = 1.0
+        self.a = parameters.create()
 
     def _update(self, params):
-        self.a = params.get_from_prefix_param(None, "a")
+        pass
 
     def _reset(self) -> None:
         pass
 
-    def required_parameters(self):
-        return RequiredParameters(["a"])
+    def _required_parameters(self):
+        return RequiredParameters([])
 
     def _get_derived_parameters(self) -> DerivedParameterCollection:
         return DerivedParameterCollection([])
@@ -75,18 +76,17 @@ class SimpleUpdatable(Updatable):
         """Initialize object with defaulted values."""
         super().__init__()
 
-        self.x = 0.0
-        self.y = 2.5
+        self.x = parameters.create()
+        self.y = parameters.create()
 
     def _update(self, params):
-        self.x = params.get_from_prefix_param(None, "x")
-        self.y = params.get_from_prefix_param(None, "y")
+        pass
 
     def _reset(self) -> None:
         pass
 
-    def required_parameters(self):
-        return RequiredParameters(["x", "y"])
+    def _required_parameters(self):
+        return RequiredParameters([])
 
     def _get_derived_parameters(self) -> DerivedParameterCollection:
         return DerivedParameterCollection([])
@@ -105,8 +105,8 @@ def test_simple_updatable():
     obj = SimpleUpdatable()
     expected_params = RequiredParameters(["x", "y"])
     assert obj.required_parameters() == expected_params
-    assert obj.x == 0.0
-    assert obj.y == 2.5
+    assert obj.x is None
+    assert obj.y is None
     new_params = ParamsMap({"x": -1.0, "y": 5.5})
     obj.update(new_params)
     assert obj.x == -1.0
@@ -120,13 +120,13 @@ def test_updatable_collection_appends():
 
     coll.append(SimpleUpdatable())
     assert len(coll) == 1
-    assert coll[0].x == 0.0
-    assert coll[0].y == 2.5
+    assert coll[0].x is None
+    assert coll[0].y is None
     assert coll.required_parameters() == RequiredParameters(["x", "y"])
 
     coll.append(MinimalUpdatable())
     assert len(coll) == 2
-    assert coll[1].a == 1.0
+    assert coll[1].a is None
     assert coll.required_parameters() == RequiredParameters(["x", "y", "a"])
 
 
@@ -136,8 +136,8 @@ def test_updatable_collection_updates():
 
     coll.append(SimpleUpdatable())
     assert len(coll) == 1
-    assert coll[0].x == 0.0
-    assert coll[0].y == 2.5
+    assert coll[0].x is None
+    assert coll[0].y is None
 
     new_params = {"x": -1.0, "y": 5.5}
     coll.update(ParamsMap(new_params))


### PR DESCRIPTION
This adds optional default parameters to `ParamsMap.get_from_prefix_param`. This is motivated by issue #193, which could have been avoided by having default values in the code, rather than some ini file.
Before merging, the correct value for `alphag` needs to be confirmed though.