### PR TITLE
Change logic of require_nonlinear_pk

### DIFF
--- a/firecrown/connector/mapping.py
+++ b/firecrown/connector/mapping.py
@@ -252,21 +252,20 @@ class MappingCosmoSIS(Mapping):
                 "delta_matter:delta_matter": p_k,
             }
 
-        if self.require_nonlinear_pk:
-            if sample.has_section("matter_power_nl"):
-                k = self.transform_k_h_to_k(sample["matter_power_nl", "k_h"])
-                z_mpl = sample["matter_power_nl", "z"]
-                scale_mpl = self.redshift_to_scale_factor(z_mpl)
-                p_k = self.transform_p_k_h3_to_p_k(sample["matter_power_nl", "p_k"])
-                p_k = self.redshift_to_scale_factor_p_k(p_k)
+        if sample.has_section("matter_power_nl"):
+            k = self.transform_k_h_to_k(sample["matter_power_nl", "k_h"])
+            z_mpl = sample["matter_power_nl", "z"]
+            scale_mpl = self.redshift_to_scale_factor(z_mpl)
+            p_k = self.transform_p_k_h3_to_p_k(sample["matter_power_nl", "p_k"])
+            p_k = self.redshift_to_scale_factor_p_k(p_k)
 
-                ccl_args["pk_nonlin"] = {
-                    "a": scale_mpl,
-                    "k": k,
-                    "delta_matter:delta_matter": p_k,
-                }
-            else:
-                ccl_args["nonlinear_model"] = "halofit"
+            ccl_args["pk_nonlin"] = {
+                "a": scale_mpl,
+                "k": k,
+                "delta_matter:delta_matter": p_k,
+            }
+        elif self.require_nonlinear_pk:
+            ccl_args["nonlinear_model"] = "halofit"
         else:
             ccl_args["nonlinear_model"] = None
 


### PR DESCRIPTION
The current use of `require_nonlinear_pk` breaks the existing 3x2pt setups that are using the `star_challenge` branch. 
This PR changes `require_nonlinear_pk==True` from "Don't use any non-linear P(k), neither from CAMB nor from CCL" to "If not provided by CAMB, compute the non-linear power spectrum in CCL". To me this make more sense for the name of the file.
`require_nonlinear_pk==False` still behaves the same when CAMB doesn't produce non-linear P(k).
