### PR TITLE
Option to allow passing user input sacc file for likelihood object etc

### DIFF
--- a/examples/srd_sn/README.md
+++ b/examples/srd_sn/README.md
@@ -71,7 +71,19 @@ EXAMPLE:
 python generate_sn_data.py ~/example data.txt sys.txt
 ```
 
+This will generate a `sacc` file with the following namenclature : `<Covariance Matrix>.sacc`
+
 REQUIREMENTS:
 
 Both the files Hubble Diagram and Covariance Matrix should be in the same folder.
 The location of which is then passed as argument `<PATH>`
+
+## Likelihood input
+
+`sn_srd.py` : reads in the `sacc` file for generating the SN likelihood object.
+
+User can pass a `sacc` data file as an argument in the following format :
+```
+python sn_srd.py input_SN_sacc_file.sacc
+```
+If no argument is provided, the default `sacc` file `srd-y1-converted.sacc` is read. 

--- a/examples/srd_sn/generate_sn_data.py
+++ b/examples/srd_sn/generate_sn_data.py
@@ -49,6 +49,10 @@ def conversion(h):
     colu = 13
     join = np.zeros((row, colu))
     hh = pd.DataFrame(np.concatenate([h, join], axis=1))
+    if np.shape(hh)[1] < 19:
+        diff = int(19 - np.shape(hh)[1])
+        for i in reversed(range(diff)):
+            hh.insert(np.shape(hh)[1], " ", np.zeros(np.shape(hh)[0]))
     hh.columns = col
     h = hh
     h["#name"] = np.linspace(0, np.shape(h)[0] - 1, np.shape(h)[0]).astype(int)
@@ -66,6 +70,7 @@ if len(sys.argv) == 4:
         y1dat = np.array(y1dat).astype(float).T
     else:
         y1dat = conversion(y1dat)
+    out_name = cov
     # print("1. SUCESS")
 else:
     dirname_year1 = "sndata/Y1_DDF_FOUNDATION"
@@ -123,6 +128,7 @@ else:
             y1cov = np.loadtxt(
                 "sndata/Y1_DDF_FOUNDATION/sys_Y1_DDF_FOUNDATION_0.txt", unpack=True
             )
+            out_name = "srd-y1-converted"
             # print("2. SUCESS")
 
 
@@ -184,7 +190,6 @@ S.metadata["simulation"] = "Y1_DDF_FOUNDATION"
 S.metadata["covmat"] = "sys_Y1_DDF_FOUNDATION_0"
 S.metadata["creation"] = datetime.datetime.now().isoformat()
 S.metadata["info"] = "SN data sets"
-S.save_fits("srd-y1-converted.sacc", overwrite=True)
-
+S.save_fits(out_name + ".sacc", overwrite=True)
 # modify this to have interpolation hubble diagrams
 # bias corrections depend on cosmology - systematic vector

--- a/examples/srd_sn/sn_srd.py
+++ b/examples/srd_sn/sn_srd.py
@@ -3,8 +3,8 @@
 import os
 import firecrown.likelihood.gauss_family.statistic.supernova as sn
 from firecrown.likelihood.gauss_family.gaussian import ConstGaussian
-
 import sacc
+import sys
 
 # Sources
 
@@ -17,10 +17,15 @@ snia_stats = sn.Supernova(sacc_tracer="sn_ddf_sample")
 lk = ConstGaussian(statistics=[snia_stats])
 
 # SACC file
-
-saccfile = os.path.expanduser(
-    os.path.expandvars("${FIRECROWN_DIR}/examples/srd_sn/srd-y1-converted.sacc")
-)
+if len(sys.argv) == 1:
+    saccfile = os.path.expanduser(
+        os.path.expandvars("${FIRECROWN_DIR}/examples/srd_sn/srd-y1-converted.sacc")
+    )
+else:
+    file = sys.argv[1]  # Input sacc file name
+    saccfile = os.path.expanduser(
+        os.path.expandvars("${FIRECROWN_DIR}/examples/srd_sn/" + file)
+    )
 sacc_data = sacc.Sacc.load_fits(saccfile)
 
 lk.read(sacc_data)


### PR DESCRIPTION
1. `sn_srd.py` : User can now pass their own `sacc` file as argument, for generating SN likelihood object.
2. `generate_sn_data.py` : Updated features in `sacc` generattion code. A sub variant of the TD `hubble diagram` file structure is readable now. For user input HD and covariance matrix, output `sacc` file naming convention updated : it will now follow the name prefix of the input covariance matrix.
3. Updated `Readme` file.