### PR TITLE
Pass FileNotFoundError exceptions in likelihood through

### DIFF
--- a/firecrown/likelihood/likelihood.py
+++ b/firecrown/likelihood/likelihood.py
@@ -97,10 +97,7 @@ def load_likelihood(filename: str) -> Likelihood:
     if spec.loader is None:
         raise ImportError(f"Spec for module '{modname}' has no loader.")
 
-    try:
-        spec.loader.exec_module(mod)
-    except FileNotFoundError as error:
-        raise ImportError(f"{error.strerror}: {filename}") from error
+    spec.loader.exec_module(mod)
 
     if not hasattr(mod, "likelihood"):
         raise ValueError(


### PR DESCRIPTION
If a likelihood raises a `FileNotFoundError`, for example due to a missing `sacc` file, that exception gets reraised as an `ImportError` with the likelihood file name and buries the actual missing file way up in the trace. See #173 and #175.

This PR removes the `try...except` block around `spec.load.exec_module`. `FileNotFoundError` now gets passed through correctly. If the actual module cannot be found, that still raises an informative exception.