### PR TITLE
211 cosmosis connector fails if sampling parameters sections is not present on the likelihood configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,8 @@
 [flake8]
 max-line-length = 88
+per-file-ignores =
+    examples/srd_sn/generate_sn_data.py:E501
 ...
 select = C,E,F,W,B,B950
 extend-ignore = E203, E501
+

--- a/firecrown/connector/cosmosis/likelihood.py
+++ b/firecrown/connector/cosmosis/likelihood.py
@@ -55,7 +55,7 @@ class FirecrownLikelihood:
 
         build_parameters = extract_section(config, option_section)
 
-        sections = config[option_section, "sampling_parameters_sections"]
+        sections = config.get_string(option_section, "sampling_parameters_sections", "")
         sections = sections.split()
 
         self.firecrown_module_name = option_section

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [flake8]
 max_line_length=88
+per-file-ignores =
+    examples/srd_sn/generate_sn_data.py:E501

--- a/tests/connector/cosmosis/test_cosmosis_module.py
+++ b/tests/connector/cosmosis/test_cosmosis_module.py
@@ -1,0 +1,22 @@
+import cosmosis.datablock
+import pytest
+from firecrown.connector.cosmosis.likelihood import FirecrownLikelihood
+
+
+@pytest.fixture(name="minimal_module_config")
+def fixture_minimal_module_config():
+    """Return a minimal CosmoSIS datablock.
+    It contains only the module's filename.
+    This is the minimal possible configuration."""
+    block = cosmosis.datablock.DataBlock()
+    block.put_string(
+        "module_options", "likelihood_source", "tests/likelihood/lkdir/lkscript.py"
+    )
+    return block
+
+
+def test_parameterless_module_construction(minimal_module_config):
+    """Make sure we can create a CosmoSIS likelihood modules that does not
+    introduce any new parameters."""
+    module = FirecrownLikelihood(minimal_module_config)
+    assert module.sampling_sections == []

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -59,15 +59,15 @@ def test_derived_parameter_wrong_type():
     """Try instantiating DerivedParameter objects with wrong types."""
 
     with pytest.raises(TypeError):
-        derived_param = DerivedParameterScalar(  # pylint: disable-msg=E0110,W0612
+        _ = DerivedParameterScalar(  # pylint: disable-msg=E0110,W0612
             "sec1", "name1", "not a float"
         )
     with pytest.raises(TypeError):
-        derived_param = DerivedParameterScalar(  # pylint: disable-msg=E0110,W0612
+        _ = DerivedParameterScalar(  # pylint: disable-msg=E0110,W0612
             "sec1", "name1", [3.14]
         )
     with pytest.raises(TypeError):
-        derived_param = DerivedParameterScalar(  # pylint: disable-msg=E0110,W0612
+        _ = DerivedParameterScalar(  # pylint: disable-msg=E0110,W0612
             "sec1", "name1", np.array([3.14])
         )
 

--- a/tests/test_updatable.py
+++ b/tests/test_updatable.py
@@ -94,11 +94,11 @@ class SimpleUpdatable(Updatable):
 
 def test_verify_abstract_interface():
     with pytest.raises(TypeError):
-        x = Missing_update()  # pylint: disable-msg=E0110,W0612
+        _ = Missing_update()  # pylint: disable-msg=E0110,W0612
     with pytest.raises(TypeError):
-        x = Missing_reset()  # pylint: disable-msg=E0110,W0612
+        _ = Missing_reset()  # pylint: disable-msg=E0110,W0612
     with pytest.raises(TypeError):
-        x = Missing_required_parameters()  # pylint: disable-msg=E0110,W0612
+        _ = Missing_required_parameters()  # pylint: disable-msg=E0110,W0612
 
 
 def test_simple_updatable():
@@ -162,7 +162,7 @@ def test_updatable_collection_construction():
 
     bad_list = [1]
     with pytest.raises(TypeError):
-        x = UpdatableCollection(bad_list)  # pylint: disable-msg=W0612
+        _ = UpdatableCollection(bad_list)  # pylint: disable-msg=W0612
 
 
 def test_updatable_collection_insertion():


### PR DESCRIPTION
This fixes issue #211 by making the configuration parameter "sampling_parameters_sections" be optional, with a default value that is an empty string.