### PR TITLE
Remove obscure (and wrong) alphag parameter from examples

### DIFF
--- a/examples/des_y1_3x2pt/cobaya_evaluate.yaml
+++ b/examples/des_y1_3x2pt/cobaya_evaluate.yaml
@@ -54,7 +54,6 @@ params:
         max: +5.0
 
 #   - these parameters are fixed
-  alphag: -1
   z_piv: 0.62
 
 #   - linear bias for lenses

--- a/examples/des_y1_3x2pt/des_y1_3x2pt.py
+++ b/examples/des_y1_3x2pt/des_y1_3x2pt.py
@@ -16,7 +16,7 @@ import sacc
 
 
 def build_likelihood(_):
-    lai_systematic = wl.LinearAlignmentSystematic(sacc_tracer="", alphag=None)
+    lai_systematic = wl.LinearAlignmentSystematic(sacc_tracer="")
 
     """
         Creating sources, each one maps to a specific section of a SACC file. In

--- a/examples/des_y1_3x2pt/des_y1_3x2pt_PT_values.ini
+++ b/examples/des_y1_3x2pt/des_y1_3x2pt_PT_values.ini
@@ -32,7 +32,6 @@ lens0_mag_bias = 0.8 1.0 1.2
 
 ia_bias = -5.0 0.5 +5.0
 alphaz = -5.0 0.0 +5.0
-alphag =  -1
 z_piv = 0.62
 
 lens0_bias = 0.8 2.0 3.0

--- a/examples/des_y1_3x2pt/des_y1_3x2pt_values.ini
+++ b/examples/des_y1_3x2pt/des_y1_3x2pt_values.ini
@@ -24,7 +24,6 @@ wa = 0.0
 
 ia_bias = -5.0 0.5 +5.0
 alphaz = -5.0 0.0 +5.0
-alphag =  -1
 z_piv = 0.62
 lens0_bias = 0.8 1.4 3.0
 lens1_bias = 0.8 1.6 3.0


### PR DESCRIPTION
The des 3x2pt example configurations still had the `alphag` parameter specified to the non-standard -1. Since this parameter is non-standard anyway and is covered by the correct default, these can be removed from the example.