### PR TITLE
Tutorial instructions for creating conda environment are incorrect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ examples/srd_sn/sndata/
 examples/*/output_*
 examples/output_*
 examples/desc_srd_v1/srd_data/LSST_DESC_SRD_v1_release
+cosmosis-standard-library/
 
 *.pytest_cache
 *.ipynb_checkpoints

--- a/docs/developer_installation.rst
+++ b/docs/developer_installation.rst
@@ -51,7 +51,7 @@ This will create a directory `cosmosis-standard-library` in whatever is your cur
 
     # conda env update, when run as suggested, is able to create a new environment, as
     # well as updating an existing environment.
-    conda env update -n firecrown_developer -f environment.yml
+    conda env update -f firecrown/environment.yml
     conda activate firecrown_developer
     source ${CONDA_PREFIX}/bin/cosmosis-configure
     cosmosis-build-standard-library
@@ -102,7 +102,7 @@ All of these are used as part of the CI system as part of the checking of all pu
 .. code:: bash
 
     # We are using type hints and mypy to help catch type-related errors.
-    mypy -p firecrown -p examples -p tests --ignore-missing-imports
+    mypy -p firecrown -p examples -p tests
 
     # We are using flake8 to help verify PEP8 compliance.
     flake8 firecrown examples tests

--- a/tutorial/development_example.qmd
+++ b/tutorial/development_example.qmd
@@ -146,7 +146,7 @@ cd THE_DIRECTORY_INTO_WHICH_YOU_WANT_TO_INSTALL_THINGS
 git clone https://github.com/LSSTDESC/firecrown.git
 # conda env update, when run as suggested, is able to create a new environment, as
 # well as updating an existing environment.
-conda env update -n firecrown_developer -f environment.yml
+conda env update -f firecrown/environment.yml
 conda activate firecrown_developer
 source ${CONDA_PREFIX}/bin/cosmosis-configure
 cosmosis-build-standard-library  # this may take a few minutes

--- a/tutorial/introduction_to_firecrown.qmd
+++ b/tutorial/introduction_to_firecrown.qmd
@@ -143,7 +143,7 @@ cd THE_DIRECTORY_INTO_WHICH_YOU_WANT_TO_INSTALL_THINGS
 git clone https://github.com/LSSTDESC/firecrown.git
 # conda env update, when run as suggested, is able to create a new environment, as
 # well as updating an existing environment.
-conda env update -n firecrown_developer -f environment.yml
+conda env update -f firecrown/environment.yml
 conda activate firecrown_developer
 source ${CONDA_PREFIX}/bin/cosmosis-configure
 cosmosis-build-standard-library  # this may take a few minutes


### PR DESCRIPTION
This pull request updates the documentation with the correct instructions for creating the conda environment for firecrown development.