### PR TITLE
Fix crash on S8 sampling in example

### DIFF
--- a/examples/cosmicshear/cosmicshear.ini
+++ b/examples/cosmicshear/cosmicshear.ini
@@ -24,14 +24,17 @@ file = ${CSL_DIR}/utility/consistency/consistency_interface.py
 [camb]
 file = ${CSL_DIR}/boltzmann/camb/camb_interface.py
 mode = all
-lmax = 2500
+lmax = 2000
 feedback = 0
 zmin = 0.0
-zmax = 4.00
+zmax = 3.00
 nz = 100
 kmin = 1e-4
 kmax = 50.0
 nk = 1000
+
+[sigma8_rescale]
+file = ${CSL_DIR}/utility/sample_sigma8/sigma8_rescale.py
 
 [firecrown_likelihood]
 ;; Fix this to use an environment variable to find the files.

--- a/examples/cosmicshear/cosmicshear_values.ini
+++ b/examples/cosmicshear/cosmicshear_values.ini
@@ -5,15 +5,15 @@
 
 ; These are the only parameters being varied.
 omega_m = 0.1 0.3 0.5
-omega_b = 0.03 0.04 0.07
 
 ; The following parameters are set, but not varied.
 ;
 ; omega_c is not set, because the consistency module sets it to omega_m - omega_b
+omega_b = 0.04
 omega_k = 0.0
 tau = 0.08
 n_s = 0.971
-sigma_8 = 0.801
+sigma_8_input = 0.801
 h0 = 0.682
 w = -1.0
 wa = 0.0


### PR DESCRIPTION
Sampling over S8 in cosmic shear example file was broken. This is a quick fix.