### PR TITLE
Re-adding codecov status checks to PRs.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,6 @@ coverage:
       default:
         target: 100%
         threshold: 0%
-        branches: [master]
         if_ci_failed: error
         only_pulls: false
 
@@ -28,7 +27,6 @@ coverage:
       default: 
         target: auto
         threshold: 0%
-        branches: [master]
         if_ci_failed: error
         only_pulls: false
         removed_code_behavior: fully_covered_patch


### PR DESCRIPTION
### Fix 
Removing the `branches` option from our `codecov.yml` configuration to re-enable status checks on PRs.

### For future reference:

After speaking with support, this option specifies which **source branches** will trigger status checks, **not target branches**.  

For example, I assumed `branches: [master]` meant, “A PR from any branch into master will trigger codecov status checks”.  However it really means “A PR from master into any other branch will trigger status checks”.

While I find this option sort of strange, since conventionally one wouldnt PR from master into any other branch, removing the branches config value from my patch and project sections completely fixed the issue.



