### PR TITLE
Allow calling get_cov when in State.COMPUTED

### DIFF
--- a/firecrown/likelihood/gauss_family/gauss_family.py
+++ b/firecrown/likelihood/gauss_family/gauss_family.py
@@ -220,7 +220,7 @@ class GaussFamily(Likelihood):
         self.inv_cov = np.linalg.inv(cov)
 
     @enforce_states(
-        initial=[State.READY, State.UPDATED],
+        initial=[State.READY, State.UPDATED, State.COMPUTED],
         failure_message="read() must be called before get_cov()",
     )
     @final


### PR DESCRIPTION
Right now `get_cov` can't get called after the theory has been computed.