### PR TITLE
Add a save_to_sacc utility function

### DIFF
--- a/firecrown/likelihood/gauss_family/gauss_family.py
+++ b/firecrown/likelihood/gauss_family/gauss_family.py
@@ -337,7 +337,7 @@ class GaussFamily(Likelihood):
         return chisq
 
     @enforce_states(
-        initial=State.READY,
+        initial=[State.READY, State.UPDATED, State.COMPUTED],
         failure_message="read() must be called before get_sacc_indices()",
     )
     def get_sacc_indices(

--- a/firecrown/likelihood/gauss_family/gauss_family.py
+++ b/firecrown/likelihood/gauss_family/gauss_family.py
@@ -27,7 +27,7 @@ from ..likelihood import Likelihood
 from ...modeling_tools import ModelingTools
 from ...updatable import UpdatableCollection
 from .statistic.statistic import Statistic, GuardedStatistic
-from ....utils import save_to_sacc
+from ...utils import save_to_sacc
 
 
 class State(Enum):

--- a/firecrown/likelihood/gauss_family/gauss_family.py
+++ b/firecrown/likelihood/gauss_family/gauss_family.py
@@ -342,7 +342,7 @@ class GaussFamily(Likelihood):
     )
     def get_sacc_indices(
         self, statistic: Union[Statistic, list[Statistic], None] = None
-    ) -> npt.NDArray[np.int]:
+    ) -> npt.NDArray[np.int64]:
         """Get the SACC indices of the statistic or list of statistics. If no
         statistic is given, get the indices of all statistics of the likelihood."""
         if statistic is None:

--- a/firecrown/utils.py
+++ b/firecrown/utils.py
@@ -1,6 +1,13 @@
 """Some utility functions for patterns common in Firecrown.
 """
 
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+import sacc
+
 
 def upper_triangle_indices(n: int):
     """generator that yields a sequence of tuples that carry the indices for an
@@ -13,3 +20,47 @@ def upper_triangle_indices(n: int):
     for i in range(n):
         for j in range(i, n):
             yield i, j
+
+
+def save_to_sacc(
+    sacc_data: sacc.Sacc,
+    data_vector: npt.NDArray[np.float64],
+    indices: npt.NDArray[np.int],
+    strict: bool = True,
+) -> sacc.Sacc:
+    """Save a data vector into a SACC object.
+
+    Arguments
+    ---------
+    sacc_data: sacc.Sacc
+        SACC object to save the data vector into.
+    data_vector: np.ndarray[float]
+        Data vector to be saved.
+    indices: np.ndarray[int]
+        SACC indices where the data vector should be written.
+    strict: bool
+        Whether to check if the data vector covers all the data already present
+        in the sacc_data.
+
+    Returns
+    -------
+    new_sacc: sacc.Sacc
+        A copy of `sacc_data`, with data at `indices` replaced with `data_vector`.
+    """
+
+    assert len(indices) == len(data_vector)
+
+    new_sacc = sacc_data.copy()
+
+    if strict:
+        if set(indices.tolist()) != set(sacc_data.indices()):
+            raise RuntimeError(
+                "The data to be saved does not cover all the data in the "
+                "sacc object. To write only the calculated predictions, "
+                "set strict=False."
+            )
+
+    for data_idx, sacc_idx in enumerate(indices):
+        new_sacc.data[sacc_idx].value = data_vector[data_idx]
+
+    return new_sacc

--- a/firecrown/utils.py
+++ b/firecrown/utils.py
@@ -28,14 +28,18 @@ def save_to_sacc(
     indices: npt.NDArray[np.int64],
     strict: bool = True,
 ) -> sacc.Sacc:
-    """Save a data vector into a SACC object.
+    """Save a data vector into a (new) SACC object, copied from `sacc_data`.
+
+    Note that the original object `sacc_data` is not modified. Its contents are
+    copied into a new object, and the new information is put into that copy,
+    which is returned by this method.
 
     Arguments
     ---------
     sacc_data: sacc.Sacc
-        SACC object to save the data vector into.
+        SACC object to be copied. It is not modified.
     data_vector: np.ndarray[float]
-        Data vector to be saved.
+        Data vector to be saved to the new copy of `sacc_data`.
     indices: np.ndarray[int]
         SACC indices where the data vector should be written.
     strict: bool

--- a/firecrown/utils.py
+++ b/firecrown/utils.py
@@ -25,7 +25,7 @@ def upper_triangle_indices(n: int):
 def save_to_sacc(
     sacc_data: sacc.Sacc,
     data_vector: npt.NDArray[np.float64],
-    indices: npt.NDArray[np.int],
+    indices: npt.NDArray[np.int64],
     strict: bool = True,
 ) -> sacc.Sacc:
     """Save a data vector into a SACC object.

--- a/tests/likelihood/gauss_family/test_const_gaussian.py
+++ b/tests/likelihood/gauss_family/test_const_gaussian.py
@@ -437,3 +437,15 @@ def test_get_sacc_indices(
             [stat.statistic.sacc_indices for stat in likelihood.statistics]
         )
     )
+
+
+def test_get_sacc_indices_single_stat(
+    trivial_stats,
+    sacc_data_for_trivial_stat: sacc.Sacc,
+):
+    likelihood = ConstGaussian(statistics=trivial_stats)
+    likelihood.read(sacc_data_for_trivial_stat)
+
+    idx = likelihood.get_sacc_indices(statistic=likelihood.statistics[0].statistic)
+
+    assert all(idx == likelihood.statistics[0].statistic.sacc_indices)

--- a/tests/likelihood/gauss_family/test_const_gaussian.py
+++ b/tests/likelihood/gauss_family/test_const_gaussian.py
@@ -420,3 +420,20 @@ def test_make_realization_no_noise(
     new_likelihood.update(params)
 
     assert_allclose(new_likelihood.get_data_vector(), likelihood.get_theory_vector())
+
+
+def test_get_sacc_indices(
+    trivial_stats,
+    sacc_data_for_trivial_stat: sacc.Sacc,
+):
+    likelihood = ConstGaussian(statistics=trivial_stats)
+    likelihood.read(sacc_data_for_trivial_stat)
+
+    idx = likelihood.get_sacc_indices()
+
+    assert all(
+        idx
+        == np.concatenate(
+            [stat.statistic.sacc_indices for stat in likelihood.statistics]
+        )
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ def test_save_to_sacc(trivial_stats, sacc_data_for_trivial_stat):
         indices=idx,
         strict=True,
     )
-    assert all([new_sacc.data[i].value == d for i, d in zip(idx, new_data_vector)])
+    assert all(new_sacc.data[i].value == d for i, d in zip(idx, new_data_vector))
 
 
 def test_save_to_sacc_strict_fail(trivial_stats, sacc_data_for_trivial_stat):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
 """
 Tests for the firecrown.utils modle.
 """
+import pytest
+import numpy as np
 
-from firecrown.utils import upper_triangle_indices
+from firecrown.utils import upper_triangle_indices, save_to_sacc
 
 
 def test_upper_triangle_indices_nonzero():
@@ -13,3 +15,33 @@ def test_upper_triangle_indices_nonzero():
 def test_upper_triangle_indices_zero():
     indices = list(upper_triangle_indices(0))
     assert not indices
+
+
+def test_save_to_sacc(trivial_stats, sacc_data_for_trivial_stat):
+    stat = trivial_stats[0]
+    stat.read(sacc_data_for_trivial_stat)
+    idx = np.arange(stat.count)
+    new_data_vector = 3 * stat.get_data_vector()[idx]
+
+    new_sacc = save_to_sacc(
+        sacc_data=sacc_data_for_trivial_stat,
+        data_vector=new_data_vector,
+        indices=idx,
+        strict=True,
+    )
+    assert all([new_sacc.data[i].value == d for i, d in zip(idx, new_data_vector)])
+
+
+def test_save_to_sacc_strict_fail(trivial_stats, sacc_data_for_trivial_stat):
+    stat = trivial_stats[0]
+    stat.read(sacc_data_for_trivial_stat)
+    idx = np.arange(stat.count - 1)
+    new_data_vector = stat.get_data_vector()[idx]
+
+    with pytest.raises(RuntimeError):
+        _ = save_to_sacc(
+            sacc_data=sacc_data_for_trivial_stat,
+            data_vector=new_data_vector,
+            indices=idx,
+            strict=True,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """
 Tests for the firecrown.utils modle.
 """
+
 import pytest
 import numpy as np
 


### PR DESCRIPTION
This PR factors out functionality in `make_realization` into a new `GaussFamiliy.get_sacc_indices` method and a `save_to_sacc` function for easier handling of sacc objects. For example, for blinding we need to write a modified data vector back to a sacc file.

Usage:
```python
idx = likelihood.get_indices()
new_sacc = save_to_sacc(
    sacc_data=sacc_data,
    data_vector=new_data_vector,
    indices=idx,
    strict=True,
)
```
TODO: ~~add tests~~