### PR TITLE
Fix flake8 whitespace complaints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu", "macos"]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup miniforge

--- a/examples/cluster_number_counts/compare_integration_methods.py
+++ b/examples/cluster_number_counts/compare_integration_methods.py
@@ -88,9 +88,10 @@ def compare_integration() -> None:
             counts_list.append(counts)
 
         t_stop = time.time()
+        delta_t = t_stop - t_start
 
         print(
-            f"The time for NumCosmo integration method {method} is {t_stop-t_start}\n\n"
+            f"The time for NumCosmo integration method {method} is {delta_t}\n\n"
             f"The counts value is {counts_list}\n\n"
         )
 

--- a/examples/des_y1_3x2pt/generate_des_data.py
+++ b/examples/des_y1_3x2pt/generate_des_data.py
@@ -127,12 +127,12 @@ with fitsio.FITS("2pt_NG_mcal_1110.fits") as data:
     # nz_lens
     dndz = data["nz_lens"].read()
     for i in range(1, n_lens + 1):
-        sacc_data.add_tracer("NZ", f"lens{i-1}", dndz["Z_MID"], dndz[f"BIN{i}"])
+        sacc_data.add_tracer("NZ", f"lens{i - 1}", dndz["Z_MID"], dndz[f"BIN{i}"])
 
     # nz_src
     dndz = data["nz_source"].read()
     for i in range(1, n_srcs + 1):
-        sacc_data.add_tracer("NZ", f"src{i-1}", dndz["Z_MID"], dndz[f"BIN{i}"])
+        sacc_data.add_tracer("NZ", f"src{i - 1}", dndz["Z_MID"], dndz[f"BIN{i}"])
 
     # xip
     xip = data["xip"].read()
@@ -148,8 +148,8 @@ with fitsio.FITS("2pt_NG_mcal_1110.fits") as data:
 
             sacc_data.add_theta_xi(
                 "galaxy_shear_xi_plus",
-                f"src{i-1}",
-                f"src{j-1}",
+                f"src{i - 1}",
+                f"src{j - 1}",
                 xip_ij["ANG"][msk],
                 xip_ij["VALUE"][msk],
             )
@@ -168,8 +168,8 @@ with fitsio.FITS("2pt_NG_mcal_1110.fits") as data:
 
             sacc_data.add_theta_xi(
                 "galaxy_shear_xi_minus",
-                f"src{i-1}",
-                f"src{j-1}",
+                f"src{i - 1}",
+                f"src{j - 1}",
                 xim_ij["ANG"][msk],
                 xim_ij["VALUE"][msk],
             )
@@ -188,8 +188,8 @@ with fitsio.FITS("2pt_NG_mcal_1110.fits") as data:
 
             sacc_data.add_theta_xi(
                 "galaxy_shearDensity_xi_t",
-                f"lens{i-1}",
-                f"src{j-1}",
+                f"lens{i - 1}",
+                f"src{j - 1}",
                 gammat_ij["ANG"][msk],
                 gammat_ij["VALUE"][msk],
             )
@@ -207,8 +207,8 @@ with fitsio.FITS("2pt_NG_mcal_1110.fits") as data:
 
         sacc_data.add_theta_xi(
             "galaxy_density_xi",
-            f"lens{i-1}",
-            f"lens{i-1}",
+            f"lens{i - 1}",
+            f"lens{i - 1}",
             wtheta_ii["ANG"][msk],
             wtheta_ii["VALUE"][msk],
         )


### PR DESCRIPTION
Under Python 3.12 with the newest version of flake8, we have several complaints about missing whitespace around operators. This PR fixes those complaints.