### PR TITLE
Release most version restrictions

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,16 +3,15 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.8
+  - python>=3.10
   - cosmosis >= 2.2.0
   - cosmosis-build-standard-library
-  - cython < 3.0.0
+  - cython
   - flake8
   - jupyter
   - mypy
   - numcosmo>=0.21.1
-  - numpy>=1.21.0
-  - plantuml
+  - numpy>=1.23.0
   - plotnine
   - pip>=20.1  # pip is needed as dependency
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -9,14 +9,14 @@ dependencies:
   - cosmosis >= 3.0
   - cosmosis-build-standard-library
   - coverage
-  - cython < 3.0.0
+  - cython
   - dill
   - fitsio
   - flake8
   - flake8-docstrings
   - fuzzywuzzy
   - getdist
-  - glib <= 2.78.4
+  - glib
   - idna
   - matplotlib-base
   - more-itertools

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - cosmosis >= 3.0
   - cosmosis-build-standard-library
   - coverage
-  - cython
+  - cython < 3.0.0
   - dill
   - fitsio
   - flake8


### PR DESCRIPTION
This releases most of our version restrictions on dependencies, because they have become obsolete.
We are still restricting the version of Sphinx because newer versions do not work for LaTeX/pdf generation.