### PR TITLE
Even more docstrings updates

### DIFF
--- a/examples/des_y1_3x2pt/des_y1_3x2pt_PT.py
+++ b/examples/des_y1_3x2pt/des_y1_3x2pt_PT.py
@@ -223,6 +223,7 @@ def run_likelihood() -> None:
 
     # Apply the systematics parameters
     likelihood.update(systematics_params)
+    tools.update(systematics_params)
 
     # Prepare the cosmology object
     tools.prepare(ccl_cosmo)
@@ -296,7 +297,7 @@ def plot_predicted_and_measured_statistics(
     # pylint: disable=import-outside-toplevel
     import matplotlib.pyplot as plt
 
-    ells = stat0.ells
+    ells = stat0.ells_for_xi
     cells = CElls(stat0, stat2, stat3)
 
     # Code that computes effect from IA using that Pk2D object
@@ -339,6 +340,9 @@ def plot_predicted_and_measured_statistics(
     fig, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
     fig.subplots_adjust(hspace=0)
     # ax[0].plot(x, y_theory, label="Total")
+    assert isinstance(ax, np.ndarray)
+    assert isinstance(ax[0], plt.Axes)
+    assert isinstance(ax[1], plt.Axes)
     ax[0].plot(ells, cells.GG, label="GG firecrown")
     ax[0].plot(ells, cl_GG, ls="--", label="GG CCL")
     ax[0].plot(ells, -cells.GI, label="-GI firecrown")

--- a/firecrown/updatable.py
+++ b/firecrown/updatable.py
@@ -38,8 +38,11 @@ class MissingSamplerParameterError(RuntimeError):
     update is missing a parameter that should have been provided by the sampler.
     """
 
-    def __init__(self, parameter: str):
-        """Create the error, with a meaning error message."""
+    def __init__(self, parameter: str) -> None:
+        """Create the error, with a meaningful error message.
+
+        :param parameter: name of the missing parameter
+        """
         self.parameter = parameter
         msg = (
             f"The parameter `{parameter}` is required to update "
@@ -63,12 +66,12 @@ class Updatable(ABC):
     def __init__(self, parameter_prefix: None | str = None) -> None:
         """Updatable initialization.
 
-        :param prefix: prefix for all parameters in this Updatable
-
         Parameters created by firecrown.parameters.create will have a prefix
         that is given by the prefix argument to the Updatable constructor. This
         prefix is used to create the full name of the parameter. If `parameter_prefix`
         is None, then the parameter will have no prefix.
+
+        :param parameter_prefix: prefix for all parameters in this Updatable
         """
         self._updated: bool = False
         self._returned_derived: bool = False
@@ -86,6 +89,9 @@ class Updatable(ABC):
         We also keep track of all :class:`Updatable` instance variables added,
         appending a reference to each to :attr:`self._updatables` as well as
         storing the attribute directly.
+
+        :param key: name of the attribute
+        :param value: value for the attribute
         """
         if isinstance(value, (Updatable, UpdatableCollection)):
             self._updatables.append(value)
@@ -101,6 +107,9 @@ class Updatable(ABC):
 
         Assure this InternalParameter or SamplerParameter has not already
         been set, and then set it.
+
+        :param key: name of the attribute
+        :param value: value for the attribute
         """
         if isinstance(value, SamplerParameter):
             value.set_fullname(self.parameter_prefix, key)
@@ -109,7 +118,11 @@ class Updatable(ABC):
             self.set_internal_parameter(key, value)
 
     def set_internal_parameter(self, key: str, value: InternalParameter) -> None:
-        """Assure this InternalParameter has not already been set, and then set it."""
+        """Assure this InternalParameter has not already been set, and then set it.
+
+        :param key: name of the attribute
+        :param value: value for the attribute
+        """
         if not isinstance(value, InternalParameter):
             raise TypeError(
                 "Can only add InternalParameter objects to internal_parameters"
@@ -124,7 +137,10 @@ class Updatable(ABC):
         super().__setattr__(key, value.get_value())
 
     def set_sampler_parameter(self, value: SamplerParameter) -> None:
-        """Assure this SamplerParameter has not already been set, and then set it."""
+        """Assure this SamplerParameter has not already been set, and then set it.
+
+        :param value: value for the attribute
+        """
         if not isinstance(value, SamplerParameter):
             raise TypeError(
                 "Can only add SamplerParameter objects to sampler_parameters"
@@ -182,10 +198,11 @@ class Updatable(ABC):
     def is_updated(self) -> bool:
         """Determine if the object has been updated.
 
-        Return True if the object is currently updated, and False if not.
         A default-constructed Updatable has not been updated. After `update`,
         but before `reset`, has been called the object is updated. After
         `reset` has been called, the object is not currently updated.
+
+        :return:  True if the object is currently updated, and False if not.
         """
         return self._updated
 
@@ -240,10 +257,12 @@ class Updatable(ABC):
 
     @final
     def required_parameters(self) -> RequiredParameters:  # pragma: no cover
-        """Returns a RequiredParameters object.
+        """Returns all information about parameters required by this object.
 
-        This object contains the information for all parameters defined in the
-        implementing class, any additional parameter.
+        This object returned contains the information for all parameters
+        defined in the implementing class, and any additional parameters.
+
+        :return: a RequiredParameters object containing all relevant parameters
         """
         sampler_parameters = RequiredParameters(self._sampler_parameters)
         additional_parameters = self._required_parameters()
@@ -262,6 +281,8 @@ class Updatable(ABC):
 
         The base class implementation returns a list with all SamplerParameter
         objects properties.
+
+        :return: a RequiredParameters containing all relevant parameters
         """
         return RequiredParameters([])
 
@@ -273,6 +294,8 @@ class Updatable(ABC):
 
         This occurs once per iteration of the statistical analysis. First call returns
         the DerivedParameterCollection, further calls return None.
+
+        :return: a collection of derived parameters, or None
         """
         if not self._updated:
             raise RuntimeError(
@@ -296,6 +319,8 @@ class Updatable(ABC):
         Derived classes can override this, returning a DerivedParameterCollection
         containing the derived parameters for the class. The default implementation
         returns an empty DerivedParameterCollection.
+
+        :return: a collection of derived parameters
         """
         return DerivedParameterCollection([])
 
@@ -335,7 +360,7 @@ class UpdatableCollection(UserList[T], Generic[T]):
     def update(self, params: ParamsMap) -> None:
         """Update self by calling update() on each contained item.
 
-        :param params: new parameter values
+        :param params: new parameter values for each contained item
         """
         if self._updated:
             return


### PR DESCRIPTION
This contains a few more updates to doscstrings.

It also contains a fix for the graphing part of the `des_y1_3x2pt_PT.py` example, which is not run in CI.