### PR TITLE
Temporary tweaks to fix CI failures from pylint 3.3

### DIFF
--- a/firecrown/models/pylintrc
+++ b/firecrown/models/pylintrc
@@ -51,6 +51,8 @@ function-naming-style=any
 
 [DESIGN]
 
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=6
 # Maximum number of arguments for function / method.
 max-args=11
 

--- a/pylintrc
+++ b/pylintrc
@@ -67,5 +67,6 @@ ignore-none=false
 expected-line-ending-format=LF
 
 [DESIGN]
+max-positional-arguments=8
 max-args=20
 max-attributes=20


### PR DESCRIPTION
This tweaks the necessary pylintrc files to avoid failures due to new warnings from pylint 3.3.