### PR TITLE
Adding conda-remove-defaults: true to conda CI options.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           activate-environment: firecrown_developer
           python-version: ${{ matrix.python-version }}
           show-channel-urls: true
+          conda-remove-defaults: true
       - name: Cache date
         id: get-date
         run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Adding conda-remove-defaults: true to conda CI options.
This assures that the defaults conda channel will not be used.

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
