### PR TITLE
Non-limber integration support in angular c_ell calculation.

### DIFF
--- a/firecrown/likelihood/two_point.py
+++ b/firecrown/likelihood/two_point.py
@@ -77,6 +77,8 @@ def calculate_angular_cl(
             (tracer0.ccl_tracer, tracer1.ccl_tracer),
             tuple(ells.ravel().tolist()),
             p_of_k_a=pk,
+            l_limber=tools.non_limber_max_ell,
+            p_of_k_a_lin=tools.ccl_cosmo.get_linear_power()
         )
         * scale0
         * scale1
@@ -685,7 +687,7 @@ class TwoPoint(Statistic):
             pk_name = f"{tracer0.field}:{tracer1.field}"
             tn = TracerNames(tracer0.tracer_name, tracer1.tracer_name)
             result = calculate_angular_cl(
-                ells, pk_name, scale0, scale1, tools, tracer0, tracer1
+                ells, pk_name, scale0, scale1, tools, tracer0, tracer1,
             )
             self.theory.cells[tn] = result
         self.theory.cells[mdt.TRACER_NAMES_TOTAL] = np.array(

--- a/firecrown/modeling_tools.py
+++ b/firecrown/modeling_tools.py
@@ -37,6 +37,7 @@ class ModelingTools(Updatable):
         cluster_abundance: None | ClusterAbundance = None,
         cluster_deltasigma: None | ClusterDeltaSigma = None,
         ccl_factory: None | CCLFactory = None,
+        non_limber_max_ell: float = -1,
     ):
         super().__init__()
         self.ccl_cosmo: None | pyccl.Cosmology = None
@@ -50,6 +51,7 @@ class ModelingTools(Updatable):
         self.cluster_abundance = cluster_abundance
         self.cluster_deltasigma = cluster_deltasigma
         self.ccl_factory = CCLFactory() if ccl_factory is None else ccl_factory
+        self.non_limber_max_ell = non_limber_max_ell
 
     def add_pk(self, name: str, powerspectrum: pyccl.Pk2D) -> None:
         """Add a :class:`pyccl.Pk2D` to the table of power spectra.

--- a/firecrown/utils.py
+++ b/firecrown/utils.py
@@ -149,6 +149,8 @@ def cached_angular_cl(
     tracers: tuple[pyccl.Tracer, pyccl.Tracer],
     ells: npt.NDArray[np.int64],
     p_of_k_a=None | Callable[[npt.NDArray[np.int64]], npt.NDArray[np.float64]],
+    l_limber=-1,
+    p_of_k_a_lin=None,
 ):
     """Wrapper for pyccl.angular_cl, with automatic caching.
 
@@ -158,7 +160,8 @@ def cached_angular_cl(
     :param p_of_k_a: function that computes the power spectrum
     """
     return pyccl.angular_cl(
-        cosmo, tracers[0], tracers[1], np.array(ells), p_of_k_a=p_of_k_a
+        cosmo, tracers[0], tracers[1], np.array(ells), p_of_k_a=p_of_k_a,
+        l_limber=l_limber, p_of_k_a_lin=p_of_k_a_lin,
     )
 
 


### PR DESCRIPTION
## Description

Adds support for non-limber integration for angular power spectra in the two-point correlation.

Fixes #504 

## Type of change

* New feature (non-breaking change which adds functionality)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [ ] I have run `bash pre-commit-check` and fixed any issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
