### PR TITLE
Change SHEAR_MINUS/PLUS to PART_OF_XI_MINUS/PLUS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
+          verbose: true
+          use_oidc: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         shell: bash -l {0}
         run: python -m pytest -vv -s --integration tests/integration 
       - name: Upload coverage reports to Codecov
-        if: ${{ (matrix.os == 'ubuntu') && (matrix.python-version == '3.11') }}
+        if: ${{ (matrix.os == 'macos') && (matrix.python-version == '3.13') }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true

--- a/firecrown/likelihood/source_factories.py
+++ b/firecrown/likelihood/source_factories.py
@@ -26,8 +26,8 @@ def use_source_factory(
         case (
             Galaxies.SHEAR_E
             | Galaxies.SHEAR_T
-            | Galaxies.SHEAR_MINUS
-            | Galaxies.SHEAR_PLUS
+            | Galaxies.PART_OF_XI_MINUS
+            | Galaxies.PART_OF_XI_PLUS
         ):
             assert wl_factory is not None
             source = wl_factory.create(inferred_galaxy_zdist)
@@ -51,8 +51,8 @@ def use_source_factory_metadata_index(
         case (
             Galaxies.SHEAR_E
             | Galaxies.SHEAR_T
-            | Galaxies.SHEAR_MINUS
-            | Galaxies.SHEAR_PLUS
+            | Galaxies.PART_OF_XI_MINUS
+            | Galaxies.PART_OF_XI_PLUS
         ):
             assert wl_factory is not None
             source = wl_factory.create_from_metadata_only(sacc_tracer)

--- a/firecrown/metadata_types.py
+++ b/firecrown/metadata_types.py
@@ -59,6 +59,18 @@ class Galaxies(YAMLSerializable, str, Enum):
     SHEAR_PLUS = 4  # For backward compatibility in user code
     COUNTS = 5
 
+    def is_shear(self) -> bool:
+        """Return True if the measurement is a shear measurement, False otherwise.
+
+        :return: True if the measurement is a shear measurement, False otherwise
+        """
+        return self in (
+            Galaxies.SHEAR_E,
+            Galaxies.SHEAR_T,
+            Galaxies.PART_OF_XI_MINUS,
+            Galaxies.PART_OF_XI_PLUS,
+        )
+
     def sacc_type_name(self) -> str:
         """Return the lower-case form of the main measurement type.
 

--- a/firecrown/metadata_types.py
+++ b/firecrown/metadata_types.py
@@ -51,11 +51,13 @@ class Galaxies(YAMLSerializable, str, Enum):
     support for more types is added to SACC this enumeration needs to be updated.
     """
 
-    SHEAR_E = auto()
-    SHEAR_T = auto()
-    SHEAR_MINUS = auto()
-    SHEAR_PLUS = auto()
-    COUNTS = auto()
+    SHEAR_E = 1
+    SHEAR_T = 2
+    PART_OF_XI_MINUS = 3
+    SHEAR_MINUS = 3  # For backward compatibility in user code
+    PART_OF_XI_PLUS = 4
+    SHEAR_PLUS = 4  # For backward compatibility in user code
+    COUNTS = 5
 
     def sacc_type_name(self) -> str:
         """Return the lower-case form of the main measurement type.
@@ -75,9 +77,9 @@ class Galaxies(YAMLSerializable, str, Enum):
             return "shear"
         if self == Galaxies.SHEAR_T:
             return "shear"
-        if self == Galaxies.SHEAR_MINUS:
+        if self == Galaxies.PART_OF_XI_MINUS:
             return "shear"
-        if self == Galaxies.SHEAR_PLUS:
+        if self == Galaxies.PART_OF_XI_PLUS:
             return "shear"
         if self == Galaxies.COUNTS:
             return "density"
@@ -93,9 +95,9 @@ class Galaxies(YAMLSerializable, str, Enum):
             return "e"
         if self == Galaxies.SHEAR_T:
             return "t"
-        if self == Galaxies.SHEAR_MINUS:
+        if self == Galaxies.PART_OF_XI_MINUS:
             return "minus"
-        if self == Galaxies.SHEAR_PLUS:
+        if self == Galaxies.PART_OF_XI_PLUS:
             return "plus"
         if self == Galaxies.COUNTS:
             return ""
@@ -236,15 +238,19 @@ Measurement = Galaxies | CMB | Clusters
 ALL_MEASUREMENTS: list[Measurement] = list(chain(Galaxies, CMB, Clusters))
 ALL_MEASUREMENT_TYPES = (Galaxies, CMB, Clusters)
 HARMONIC_ONLY_MEASUREMENTS = (Galaxies.SHEAR_E,)
-REAL_ONLY_MEASUREMENTS = (Galaxies.SHEAR_T, Galaxies.SHEAR_MINUS, Galaxies.SHEAR_PLUS)
-EXACT_MATCH_MEASUREMENTS = (Galaxies.SHEAR_MINUS, Galaxies.SHEAR_PLUS)
+REAL_ONLY_MEASUREMENTS = (
+    Galaxies.SHEAR_T,
+    Galaxies.PART_OF_XI_MINUS,
+    Galaxies.PART_OF_XI_PLUS,
+)
+EXACT_MATCH_MEASUREMENTS = (Galaxies.PART_OF_XI_MINUS, Galaxies.PART_OF_XI_PLUS)
 LENS_REGEX = re.compile(r"^lens\d+$")
 SOURCE_REGEX = re.compile(r"^(src\d+|source\d+)$")
 GALAXY_SOURCE_TYPES = (
     Galaxies.SHEAR_E,
     Galaxies.SHEAR_T,
-    Galaxies.SHEAR_MINUS,
-    Galaxies.SHEAR_PLUS,
+    Galaxies.PART_OF_XI_MINUS,
+    Galaxies.PART_OF_XI_PLUS,
 )
 GALAXY_LENS_TYPES = (Galaxies.COUNTS,)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,8 +231,8 @@ def make_all_harmonic_bins() -> list[InferredGalaxyZDist]:
     params=[
         Galaxies.COUNTS,
         Galaxies.SHEAR_T,
-        Galaxies.SHEAR_MINUS,
-        Galaxies.SHEAR_PLUS,
+        Galaxies.PART_OF_XI_MINUS,
+        Galaxies.PART_OF_XI_PLUS,
     ],
     ids=["counts", "shear_t", "shear_minus", "shear_plus"],
 )
@@ -252,8 +252,8 @@ def make_real_bin_1(request) -> InferredGalaxyZDist:
     params=[
         Galaxies.COUNTS,
         Galaxies.SHEAR_T,
-        Galaxies.SHEAR_MINUS,
-        Galaxies.SHEAR_PLUS,
+        Galaxies.PART_OF_XI_MINUS,
+        Galaxies.PART_OF_XI_PLUS,
     ],
     ids=["counts", "shear_t", "shear_minus", "shear_plus"],
 )
@@ -284,8 +284,8 @@ def make_all_real_bins() -> list[InferredGalaxyZDist]:
         for m in [
             Galaxies.COUNTS,
             Galaxies.SHEAR_T,
-            Galaxies.SHEAR_MINUS,
-            Galaxies.SHEAR_PLUS,
+            Galaxies.PART_OF_XI_MINUS,
+            Galaxies.PART_OF_XI_PLUS,
         ]
     ]
 

--- a/tests/likelihood/gauss_family/statistic/test_two_point.py
+++ b/tests/likelihood/gauss_family/statistic/test_two_point.py
@@ -562,7 +562,7 @@ def test_use_source_factory_invalid_measurement(
         ValueError,
         match="Measurement .* not found in inferred galaxy redshift distribution .*",
     ):
-        use_source_factory(harmonic_bin_1, Galaxies.SHEAR_MINUS, None, None)
+        use_source_factory(harmonic_bin_1, Galaxies.PART_OF_XI_MINUS, None, None)
 
 
 def test_use_source_factory_metadata_only_counts(

--- a/tests/metadata/test_metadata_two_point_types.py
+++ b/tests/metadata/test_metadata_two_point_types.py
@@ -409,15 +409,15 @@ def test_match_name_type_require_convention_source():
     match, n1, a, n2, b = match_name_type(
         "src0",
         "src0",
-        Galaxies.SHEAR_MINUS,
-        Galaxies.SHEAR_MINUS,
+        Galaxies.PART_OF_XI_MINUS,
+        Galaxies.PART_OF_XI_MINUS,
         require_convetion=True,
     )
     assert not match
     assert n1 == "src0"
-    assert a == Galaxies.SHEAR_MINUS
+    assert a == Galaxies.PART_OF_XI_MINUS
     assert n2 == "src0"
-    assert b == Galaxies.SHEAR_MINUS
+    assert b == Galaxies.PART_OF_XI_MINUS
 
 
 def test_check_two_point_consistence_harmonic(two_point_cell: TwoPointHarmonic):

--- a/tests/metadata/test_metadata_two_point_types.py
+++ b/tests/metadata/test_metadata_two_point_types.py
@@ -65,6 +65,16 @@ def test_order_enums():
         assert compare_enums(enumerand, enumerand) == 0
 
 
+def test_galaxies_is_shear():
+    assert Galaxies.PART_OF_XI_MINUS is Galaxies.SHEAR_MINUS
+    assert Galaxies.PART_OF_XI_PLUS is Galaxies.SHEAR_PLUS
+    assert Galaxies.SHEAR_E.is_shear()
+    assert Galaxies.SHEAR_T.is_shear()
+    assert Galaxies.PART_OF_XI_MINUS.is_shear()
+    assert Galaxies.PART_OF_XI_PLUS.is_shear()
+    assert not Galaxies.COUNTS.is_shear()
+
+
 def test_compare_enums_wrong_type():
     with pytest.raises(
         ValueError,

--- a/tests/metadata/test_metadata_two_point_types.py
+++ b/tests/metadata/test_metadata_two_point_types.py
@@ -213,8 +213,8 @@ def test_extract_all_tracers_types_reals(sacc_galaxy_xis: tuple[sacc.Sacc, dict,
         if SOURCE_REGEX.match(tracer):
             assert measurements == {
                 Galaxies.SHEAR_T,
-                Galaxies.SHEAR_MINUS,
-                Galaxies.SHEAR_PLUS,
+                Galaxies.PART_OF_XI_MINUS,
+                Galaxies.PART_OF_XI_PLUS,
             }
 
 
@@ -232,8 +232,8 @@ def test_extract_all_tracers_types_reals_inverted(
         if SOURCE_REGEX.match(tracer):
             assert measurements == {
                 Galaxies.SHEAR_T,
-                Galaxies.SHEAR_MINUS,
-                Galaxies.SHEAR_PLUS,
+                Galaxies.PART_OF_XI_MINUS,
+                Galaxies.PART_OF_XI_PLUS,
             }
 
 


### PR DESCRIPTION
## Description

This renames the enumeration values Galaxies.SHEAR_MINUS and Galaxies.SHEAR_PLUS to Galaxies.PART_OF_XI_MINUS and Galaxies.PART_OF_XI_PLUS throughout. The old names are left in place as aliases for backwards compatibility of existing code that is using the old names. New code should use the new names.

Fixes #509

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* New feature (non-breaking change which adds functionality)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
