### PR TITLE
Minor updates to make firecrown tests run with SACC 1.0.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - pyyaml
   - quarto
   - requests
-  - sacc >= 0.11
+  - sacc >= 1.0
   - scipy
   - sphinx
   - sphinx-autoapi

--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - pyyaml
   - quarto
   - requests
-  - sacc >= 1.0
+  - sacc >= 0.11
   - scipy
   - sphinx
   - sphinx-autoapi

--- a/firecrown/ccl_factory.py
+++ b/firecrown/ccl_factory.py
@@ -311,7 +311,7 @@ class CCLFactory(Updatable, BaseModel):
         BaseModel.__init__(self, **data)
         Updatable.__init__(self, parameter_prefix=parameter_prefix)
 
-        if set(data) - set(self.model_fields.keys()):
+        if set(data) - set(CCLFactory.model_fields.keys()):
             raise ValueError(
                 f"Invalid parameters: {set(data) - set(self.model_fields.keys())}"
             )

--- a/tests/likelihood/gauss_family/statistic/test_two_point.py
+++ b/tests/likelihood/gauss_family/statistic/test_two_point.py
@@ -333,7 +333,7 @@ def test_two_point_src0_src0_cuts(sacc_galaxy_cells_src0_src0) -> None:
         "galaxy_shear_cl_ee", src0, src0, ell_or_theta_min=50, ell_or_theta_max=200
     )
     with pytest.warns(
-        UserWarning, match="No bandpower windows associated to these data"
+        UserWarning, match="No bandpower windows associated with these data"
     ):
         statistic.read(sacc_data)
     assert statistic.theory.ell_or_theta_min == 50

--- a/tests/likelihood/gauss_family/statistic/test_two_point.py
+++ b/tests/likelihood/gauss_family/statistic/test_two_point.py
@@ -333,7 +333,7 @@ def test_two_point_src0_src0_cuts(sacc_galaxy_cells_src0_src0) -> None:
         "galaxy_shear_cl_ee", src0, src0, ell_or_theta_min=50, ell_or_theta_max=200
     )
     with pytest.warns(
-        UserWarning, match="No bandpower windows associated with these data"
+        UserWarning, match="No bandpower windows associated (with|to) these data"
     ):
         statistic.read(sacc_data)
     assert statistic.theory.ell_or_theta_min == 50

--- a/tests/metadata/test_metadata_two_point_sacc.py
+++ b/tests/metadata/test_metadata_two_point_sacc.py
@@ -39,7 +39,7 @@ from firecrown.likelihood.source_factories import use_source_factory
 
 
 @pytest.fixture(name="sacc_galaxy_src0_src0_invalid_data_type")
-def fixture_sacc_galaxy_src0_src0_invalid_data_type():
+def fixture_sacc_galaxy_src0_src0_invalid_data_type(recwarn):
     """Fixture for a SACC data without window functions."""
     sacc_data = sacc.Sacc()
 
@@ -51,6 +51,12 @@ def fixture_sacc_galaxy_src0_src0_invalid_data_type():
 
     Cells = np.random.normal(size=ells.shape[0])
     sacc_data.add_ell_cl("this_type_is_invalid", "src0", "src0", ells, Cells)
+    warning = next(iter(recwarn), None)
+    if warning is not None:
+        assert isinstance(warning.message, UserWarning)
+        assert re.match(
+            r"Unknown data_type value this_type_is_invalid\.", str(warning.message)
+        )
 
     cov = np.diag(np.ones_like(Cells) * 0.01)
     sacc_data.add_covariance(cov)

--- a/tests/metadata/test_metadata_two_point_sacc.py
+++ b/tests/metadata/test_metadata_two_point_sacc.py
@@ -50,8 +50,7 @@ def fixture_sacc_galaxy_src0_src0_invalid_data_type():
     sacc_data.add_tracer("NZ", "src0", z, dndz)
 
     Cells = np.random.normal(size=ells.shape[0])
-    with pytest.warns(UserWarning):
-        sacc_data.add_ell_cl("this_type_is_invalid", "src0", "src0", ells, Cells)
+    sacc_data.add_ell_cl("this_type_is_invalid", "src0", "src0", ells, Cells)
 
     cov = np.diag(np.ones_like(Cells) * 0.01)
     sacc_data.add_covariance(cov)


### PR DESCRIPTION
This will work when/if the PR for SACC backward compatibility is accepted and a new release is made.

## Description

A few warning messages were updated in the new SACC version. This PR updates them so the tests can run. This makes firecrown required new SACC version. 

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
