### PR TITLE
Avoid hard-wired SACC filenames

### DIFF
--- a/examples/des_y1_3x2pt/cobaya/evaluate.yaml
+++ b/examples/des_y1_3x2pt/cobaya/evaluate.yaml
@@ -9,6 +9,7 @@ likelihood:
     input_style: CAMB
     external: !!python/name:firecrown.connector.cobaya.likelihood.LikelihoodConnector ''
     firecrownIni: ${FIRECROWN_DIR}/examples/des_y1_3x2pt/factory.py
+      sacc_file: ${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits
     derived_parameters: 
     - TwoPoint__NumberCountsScale_lens0
     - TwoPoint__NumberCountsScale_lens1

--- a/examples/des_y1_3x2pt/cobaya/evaluate_mu_sigma.yaml
+++ b/examples/des_y1_3x2pt/cobaya/evaluate_mu_sigma.yaml
@@ -4,6 +4,7 @@ likelihood:
     firecrownIni: firecrown.likelihood.factories.build_two_point_likelihood
     build_parameters:
       likelihood_config: ${FIRECROWN_DIR}/examples/des_y1_3x2pt/mu_sigma_experiment.yaml
+      sacc_file: ${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits
 params:
   sigma8:
     prior:

--- a/examples/des_y1_3x2pt/cosmosis/default_factory.ini
+++ b/examples/des_y1_3x2pt/cosmosis/default_factory.ini
@@ -42,6 +42,7 @@ nk = 1000
 file = ${FIRECROWN_DIR}/firecrown/connector/cosmosis/likelihood.py
 likelihood_source = firecrown.likelihood.factories.build_two_point_likelihood
 likelihood_config = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/experiment.yaml
+sacc_file = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits
 ;; Connector settings
 require_nonlinear_pk = True
 sampling_parameters_sections = firecrown_two_point

--- a/examples/des_y1_3x2pt/cosmosis/factory.ini
+++ b/examples/des_y1_3x2pt/cosmosis/factory.ini
@@ -43,6 +43,7 @@ nk = 1000
 ;; installed it)
 file = ${FIRECROWN_DIR}/firecrown/connector/cosmosis/likelihood.py
 likelihood_source = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/factory.py
+sacc_file = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits
 require_nonlinear_pk = True
 sampling_parameters_sections = firecrown_two_point
 

--- a/examples/des_y1_3x2pt/cosmosis/factory_PT.ini
+++ b/examples/des_y1_3x2pt/cosmosis/factory_PT.ini
@@ -40,6 +40,7 @@ nk = 1000
 ;; installed it)
 file = ${FIRECROWN_DIR}/firecrown/connector/cosmosis/likelihood.py
 likelihood_source = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/factory_PT.py
+sacc_file = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits"
 require_nonlinear_pk = True
 sampling_parameters_sections = firecrown_two_point
 

--- a/examples/des_y1_3x2pt/cosmosis/mu_sigma.ini
+++ b/examples/des_y1_3x2pt/cosmosis/mu_sigma.ini
@@ -28,6 +28,7 @@ file = ${CSL_DIR}/utility/consistency/consistency_interface.py
 file = ${FIRECROWN_DIR}/firecrown/connector/cosmosis/likelihood.py
 likelihood_source = firecrown.likelihood.factories.build_two_point_likelihood
 likelihood_config = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/mu_sigma_experiment.yaml
+sacc_file = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits"
 ;; Connector settings
 require_nonlinear_pk = True
 sampling_parameters_sections = firecrown_two_point

--- a/examples/des_y1_3x2pt/cosmosis/pure_ccl.ini
+++ b/examples/des_y1_3x2pt/cosmosis/pure_ccl.ini
@@ -28,6 +28,7 @@ file = ${CSL_DIR}/utility/consistency/consistency_interface.py
 file = ${FIRECROWN_DIR}/firecrown/connector/cosmosis/likelihood.py
 likelihood_source = firecrown.likelihood.factories.build_two_point_likelihood
 likelihood_config = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/pure_ccl_experiment.yaml
+sacc_file = ${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits"
 ;; Connector settings
 require_nonlinear_pk = True
 sampling_parameters_sections = firecrown_two_point

--- a/examples/des_y1_3x2pt/factory.py
+++ b/examples/des_y1_3x2pt/factory.py
@@ -1,8 +1,8 @@
 """The DES Y1 3x2pt likelihood factory module."""
 
-import os
 import sacc
 
+from firecrown.likelihood.likelihood import NamedParameters
 import firecrown.likelihood.weak_lensing as wl
 import firecrown.likelihood.number_counts as nc
 from firecrown.likelihood.two_point import TwoPoint
@@ -18,7 +18,7 @@ from firecrown.ccl_factory import CCLFactory
 #  segment of the data. These sources are created using the build_likelihood function
 # and also contain a list of systematics. The systematics are classes that modify the
 # theoretical prediction and are also constructed in the build_likelihood function.
-def build_likelihood(_):
+def build_likelihood(params: NamedParameters) -> tuple[ConstGaussian, ModelingTools]:
     """Build the DES Y1 3x2pt likelihood."""
     # Creates a LAI systematic. This is a systematic that is applied to
     # all weak-lensing probes. The `sacc_tracer` argument is used to identify the
@@ -101,10 +101,8 @@ def build_likelihood(_):
     likelihood = ConstGaussian(statistics=list(stats.values()))
 
     # We load the correct SACC file.
-    saccfile = os.path.expanduser(
-        os.path.expandvars("${FIRECROWN_DIR}/examples/des_y1_3x2pt/sacc_data.fits")
-    )
-    sacc_data = sacc.Sacc.load_fits(saccfile)
+    sacc_file = params.get_string("sacc_file")
+    sacc_data = sacc.Sacc.load_fits(sacc_file)
 
     # The read likelihood method is called passing the loaded SACC file, the
     # two-point functions will receive the appropriated sections of the SACC


### PR DESCRIPTION
## Description

This removes the use of hard-coded SACC filenames from examples.

Fixes #515

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [ ] I have run `bash pre-commit-check` and fixed any issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
