### PR TITLE
Improve names of constants and functions for SRD-related bins

### DIFF
--- a/firecrown/generators/inferred_galaxy_zdist.py
+++ b/firecrown/generators/inferred_galaxy_zdist.py
@@ -531,7 +531,7 @@ def get_y10_source_bins() -> BinsType:
 
 
 @cache
-def get_lsst_y1_lens_bin_collection() -> ZDistLSSTSRDBinCollection:
+def get_lsst_y1_lens_harmonic_bin_collection() -> ZDistLSSTSRDBinCollection:
     """Get the LSST Year 1 lens bin collection."""
     y1_lens_bins = get_y1_lens_bins()
     return ZDistLSSTSRDBinCollection(
@@ -553,7 +553,7 @@ def get_lsst_y1_lens_bin_collection() -> ZDistLSSTSRDBinCollection:
 
 
 @cache
-def get_lsst_y1_source_bin_collection() -> ZDistLSSTSRDBinCollection:
+def get_lsst_y1_source_harmonic_bin_collection() -> ZDistLSSTSRDBinCollection:
     """Get the LSST Year 1 source bin collection."""
     y1_source_bins = get_y1_source_bins()
     return ZDistLSSTSRDBinCollection(
@@ -575,7 +575,7 @@ def get_lsst_y1_source_bin_collection() -> ZDistLSSTSRDBinCollection:
 
 
 @cache
-def get_lsst_y10_lens_bin_collection() -> ZDistLSSTSRDBinCollection:
+def get_lsst_y10_lens_harmonic_bin_collection() -> ZDistLSSTSRDBinCollection:
     """Get the LSST Year 10 lens bin collection."""
     y10_lens_bins = get_y10_lens_bins()
     return ZDistLSSTSRDBinCollection(
@@ -597,7 +597,7 @@ def get_lsst_y10_lens_bin_collection() -> ZDistLSSTSRDBinCollection:
 
 
 @cache
-def get_lsst_y10_source_bin_collection() -> ZDistLSSTSRDBinCollection:
+def get_lsst_y10_source_harmonic_bin_collection() -> ZDistLSSTSRDBinCollection:
     """Get the LSST Year 10 source bin collection."""
     y10_source_bins = get_y10_source_bins()
     return ZDistLSSTSRDBinCollection(
@@ -629,14 +629,14 @@ def __getattr__(name: str) -> Any:  # pylint: disable-msg=too-many-return-statem
             return get_y10_lens_bins()
         case "Y10_SOURCE_BINS":
             return get_y10_source_bins()
-        case "LSST_Y1_LENS_BIN_COLLECTION":
-            return get_lsst_y1_lens_bin_collection()
-        case "LSST_Y1_SOURCE_BIN_COLLECTION":
-            return get_lsst_y1_source_bin_collection()
-        case "LSST_Y10_LENS_BIN_COLLECTION":
-            return get_lsst_y10_lens_bin_collection()
-        case "LSST_Y10_SOURCE_BIN_COLLECTION":
-            return get_lsst_y10_source_bin_collection()
+        case "LSST_Y1_LENS_HARMONIC_BIN_COLLECTION":
+            return get_lsst_y1_lens_harmonic_bin_collection()
+        case "LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION":
+            return get_lsst_y1_source_harmonic_bin_collection()
+        case "LSST_Y10_LENS_HARMONIC_BIN_COLLECTION":
+            return get_lsst_y10_lens_harmonic_bin_collection()
+        case "LSST_Y10_SOURCE_HARMONIC_BIN_COLLECTION":
+            return get_lsst_y10_source_harmonic_bin_collection()
         case _:
             raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
@@ -645,7 +645,7 @@ Y1_LENS_BINS: BinsType
 Y1_SOURCE_BINS: BinsType
 Y10_LENS_BINS: BinsType
 Y10_SOURCE_BINS: BinsType
-LSST_Y1_LENS_BIN_COLLECTION: ZDistLSSTSRDBinCollection
-LSST_Y1_SOURCE_BIN_COLLECTION: ZDistLSSTSRDBinCollection
-LSST_Y10_LENS_BIN_COLLECTION: ZDistLSSTSRDBinCollection
-LSST_Y10_SOURCE_BIN_COLLECTION: ZDistLSSTSRDBinCollection
+LSST_Y1_LENS_HARMONIC_BIN_COLLECTION: ZDistLSSTSRDBinCollection
+LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION: ZDistLSSTSRDBinCollection
+LSST_Y10_LENS_HARMONIC_BIN_COLLECTION: ZDistLSSTSRDBinCollection
+LSST_Y10_SOURCE_HARMONIC_BIN_COLLECTION: ZDistLSSTSRDBinCollection

--- a/tests/generators/test_inferred_galaxy_zdist.py
+++ b/tests/generators/test_inferred_galaxy_zdist.py
@@ -23,10 +23,10 @@ from firecrown.generators.inferred_galaxy_zdist import (
     LinearGrid1D,
     ZDistLSSTSRDBin,
     ZDistLSSTSRDBinCollection,
-    LSST_Y1_LENS_BIN_COLLECTION,
-    LSST_Y1_SOURCE_BIN_COLLECTION,
-    LSST_Y10_LENS_BIN_COLLECTION,
-    LSST_Y10_SOURCE_BIN_COLLECTION,
+    LSST_Y1_LENS_HARMONIC_BIN_COLLECTION,
+    LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION,
+    LSST_Y10_LENS_HARMONIC_BIN_COLLECTION,
+    LSST_Y10_SOURCE_HARMONIC_BIN_COLLECTION,
     Measurement,
     make_measurements,
     make_measurements_dict,
@@ -114,27 +114,27 @@ def fixture_zdist_bins(request) -> list[ZDistLSSTSRDBin]:
     """Fixture for the ZDistLSSTSRD class."""
     match request.param[0]:
         case "one_lens_y1":
-            bins = copy.deepcopy(LSST_Y1_LENS_BIN_COLLECTION.bins[0:1])
+            bins = copy.deepcopy(LSST_Y1_LENS_HARMONIC_BIN_COLLECTION.bins[0:1])
         case "all_lens_y1":
-            bins = copy.deepcopy(LSST_Y1_LENS_BIN_COLLECTION.bins)
+            bins = copy.deepcopy(LSST_Y1_LENS_HARMONIC_BIN_COLLECTION.bins)
         case "one_source_y1":
-            bins = copy.deepcopy(LSST_Y1_SOURCE_BIN_COLLECTION.bins[0:1])
+            bins = copy.deepcopy(LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION.bins[0:1])
         case "all_source_y1":
-            bins = copy.deepcopy(LSST_Y1_SOURCE_BIN_COLLECTION.bins)
+            bins = copy.deepcopy(LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION.bins)
         case "lens_and_source_y1":
-            bins = copy.deepcopy(LSST_Y1_LENS_BIN_COLLECTION.bins)
-            bins.extend(copy.deepcopy(LSST_Y1_SOURCE_BIN_COLLECTION.bins))
+            bins = copy.deepcopy(LSST_Y1_LENS_HARMONIC_BIN_COLLECTION.bins)
+            bins.extend(copy.deepcopy(LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION.bins))
         case "one_lens_y10":
-            bins = copy.deepcopy(LSST_Y10_LENS_BIN_COLLECTION.bins[0:1])
+            bins = copy.deepcopy(LSST_Y10_LENS_HARMONIC_BIN_COLLECTION.bins[0:1])
         case "all_lens_y10":
-            bins = copy.deepcopy(LSST_Y10_LENS_BIN_COLLECTION.bins)
+            bins = copy.deepcopy(LSST_Y10_LENS_HARMONIC_BIN_COLLECTION.bins)
         case "one_source_y10":
-            bins = copy.deepcopy(LSST_Y10_SOURCE_BIN_COLLECTION.bins[0:1])
+            bins = copy.deepcopy(LSST_Y10_SOURCE_HARMONIC_BIN_COLLECTION.bins[0:1])
         case "all_source_y10":
-            bins = copy.deepcopy(LSST_Y10_SOURCE_BIN_COLLECTION.bins)
+            bins = copy.deepcopy(LSST_Y10_SOURCE_HARMONIC_BIN_COLLECTION.bins)
         case "lens_and_source_y10":
-            bins = copy.deepcopy(LSST_Y10_LENS_BIN_COLLECTION.bins)
-            bins.extend(copy.deepcopy(LSST_Y10_SOURCE_BIN_COLLECTION.bins))
+            bins = copy.deepcopy(LSST_Y10_LENS_HARMONIC_BIN_COLLECTION.bins)
+            bins.extend(copy.deepcopy(LSST_Y10_SOURCE_HARMONIC_BIN_COLLECTION.bins))
         case _:
             raise ValueError(f"Invalid parameter: {request.param}")
 

--- a/tests/integration/test_des_y1_3x2pt.py
+++ b/tests/integration/test_des_y1_3x2pt.py
@@ -82,7 +82,7 @@ def test_des_y1_3x2pt_cobaya(cobaya_yaml_file: str):
             f"""
                 set -e
                 cd examples/des_y1_3x2pt
-                cobaya-run cobaya/{cobaya_yaml_file}
+                cobaya-run -f cobaya/{cobaya_yaml_file}
             """,
         ],
         capture_output=True,

--- a/tutorial/_quarto.yml
+++ b/tutorial/_quarto.yml
@@ -65,7 +65,7 @@ format:
 
 reference-location: margin
 citation-location: margin
-subtitle: "version 1.10.0"
+subtitle: "version 1.11.0a0"
 authors:
   - Marc Paterno
   - Sandro Vitenti

--- a/tutorial/inferred_zdist_serialization.qmd
+++ b/tutorial/inferred_zdist_serialization.qmd
@@ -128,18 +128,18 @@ pprint(zdist)
 ## LSST SRD redshift distributions {#sec-lsst-srd}
 
 The LSST SRD provides the parameters used to generate the redshift distributions.
-Firecrown includes dataclass instances `LSST_Y1_LENS_BIN_COLLECTION` and `LSST_Y1_SOURCE_BIN_COLLECTION`, which store the parameters for generating redshift distributions for the Y1 lens and source samples, respectively.
-Similar collections, `LSST_Y10_LENS_BIN_COLLECTION` and `LSST_Y10_SOURCE_BIN_COLLECTION`, exist for the Y10 samples.
+Firecrown includes dataclass instances `LSST_Y1_LENS_HARMONIC_BIN_COLLECTION` and `LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION`, which store the parameters for generating redshift distributions for the Y1 lens and source samples, respectively.
+Similar collections, `LSST_Y10_LENS_HARMONIC_BIN_COLLECTION` and `LSST_Y10_SOURCE_HARMONIC_BIN_COLLECTION`, exist for the Y10 samples.
 
 Below is a code snippet demonstrating how to serialize and read back these dataclasses:
 ```{python}
 from firecrown.generators.inferred_galaxy_zdist import (
-    LSST_Y1_LENS_BIN_COLLECTION,
-    LSST_Y1_SOURCE_BIN_COLLECTION,
+    LSST_Y1_LENS_HARMONIC_BIN_COLLECTION,
+    LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION,
 )
 
-lsst_y1_lens_yaml = base_model_to_yaml(LSST_Y1_LENS_BIN_COLLECTION)
-lsst_y1_source_yaml = base_model_to_yaml(LSST_Y1_SOURCE_BIN_COLLECTION)
+lsst_y1_lens_yaml = base_model_to_yaml(LSST_Y1_LENS_HARMONIC_BIN_COLLECTION)
+lsst_y1_source_yaml = base_model_to_yaml(LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION)
 
 ```
 

--- a/tutorial/two_point_factories.qmd
+++ b/tutorial/two_point_factories.qmd
@@ -387,7 +387,7 @@ The example below shows how to create a [[likelihood.two_point|TwoPointFactory]]
 We also create additional [[likelihood.two_point|TwoPointFactory]] objects with alternative integration configurations: [[utils|ClIntegrationMethod.LIMBER]] with [[utils|ClLimberMethod.GSL_SPLINE]], [[utils|ClIntegrationMethod.FKEM_AUTO]], and [[utils|ClIntegrationMethod.FKEM_L_LIMBER]].  
 
 The lens and source redshift bin collections used for the computations are imported from the `firecrown.generators.inferred_galaxy_zdist` module:  
-[[generators.inferred_galaxy_zdist|LSST_Y1_LENS_BIN_COLLECTION]] and [[generators.inferred_galaxy_zdist|LSST_Y1_SOURCE_BIN_COLLECTION]].
+[[generators.inferred_galaxy_zdist|LSST_Y1_LENS_HARMONIC_BIN_COLLECTION]] and [[generators.inferred_galaxy_zdist|LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION]].
 
 ```{python}
 import numpy as np
@@ -396,12 +396,12 @@ from firecrown.metadata_functions import (
     TwoPointHarmonic,
 )
 from firecrown.generators.inferred_galaxy_zdist import (
-    LSST_Y1_LENS_BIN_COLLECTION,
-    LSST_Y1_SOURCE_BIN_COLLECTION,
+    LSST_Y1_LENS_HARMONIC_BIN_COLLECTION,
+    LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION,
 )
 
-count_bins = LSST_Y1_LENS_BIN_COLLECTION.generate()
-shear_bins = LSST_Y1_SOURCE_BIN_COLLECTION.generate()
+count_bins = LSST_Y1_LENS_HARMONIC_BIN_COLLECTION.generate()
+shear_bins = LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION.generate()
 all_y1_bins = count_bins[:1] + shear_bins[:1]
 
 all_two_point_xy = make_all_photoz_bin_combinations(all_y1_bins)

--- a/tutorial/two_point_generators.qmd
+++ b/tutorial/two_point_generators.qmd
@@ -26,12 +26,12 @@ Here we will use the LSST SRD year 1 redshift distribution to generate the two-p
 
 ```{python}
 from firecrown.generators.inferred_galaxy_zdist import (
-    LSST_Y1_LENS_BIN_COLLECTION,
-    LSST_Y1_SOURCE_BIN_COLLECTION,
+    LSST_Y1_LENS_HARMONIC_BIN_COLLECTION,
+    LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION,
 )
 
-count_bins = LSST_Y1_LENS_BIN_COLLECTION.generate()
-shear_bins = LSST_Y1_SOURCE_BIN_COLLECTION.generate()
+count_bins = LSST_Y1_LENS_HARMONIC_BIN_COLLECTION.generate()
+shear_bins = LSST_Y1_SOURCE_HARMONIC_BIN_COLLECTION.generate()
 all_y1_bins = count_bins + shear_bins
 ```
 


### PR DESCRIPTION
## Description

This PR changes the names of the module-level constants, and some functions, associated with the SRD binning. This is to make it more clear that the SRD only discusses *harmonic space* analysis.

Fixes # 508

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [ ] I have run `bash pre-commit-check` and fixed any issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
