### PR TITLE
Add running Smokescreen tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,74 @@ jobs:
           use_oidc: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  test-smokescreen:
+    name: Firecrown Smokescreen (${{ matrix.os }}, python-${{ matrix.python-version }}, Miniforge)
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos"]
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cloning Smokescreen
+        uses: actions/checkout@v4
+        with:
+          repository: 'lsstdesc/smokescreen'
+          path: 'smokescreen'
+          branch: 'fix-updated-firecrown'
+          # Instead of 'branch', 
+          # Use fetch-tag once we have a new release tag to use
+      - name: Setting up Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          python-version: ${{ matrix.python-version }}
+          show-channel-urls: true
+          conda-remove-defaults: true
+          environment-file: environment.yml
+          activate-environment: firecrown_developer
+      - name: Cache date
+        id: get-date
+        run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Cache Conda env
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CONDA }}/envs
+          key: miniforge-${{ runner.os }}--${{ runner.arch }}--python-${{ matrix.python-version }}--${{ steps.get-date.outputs.today }}-${{ hashFiles('environment.yml') }}-${{ env.CACHE_NUMBER }}
+        env:
+          CACHE_NUMBER: 1
+        id: cache
+      - name: Setting up Firecrown
+        shell: bash -l {0}
+        run: |
+          export FIRECROWN_DIR=${PWD}
+          conda env config vars set FIRECROWN_DIR=${FIRECROWN_DIR}
+          conda activate firecrown_developer
+          pip install --no-deps -e .
+          conda list
+      - name: Setting up CosmoSIS    
+        shell: bash -l {0}
+        run: |
+          source ${CONDA_PREFIX}/bin/cosmosis-configure
+          pushd ${CONDA_PREFIX}
+          cosmosis-build-standard-library
+          export CSL_DIR=${PWD}/cosmosis-standard-library
+          conda env config vars set CSL_DIR=${CSL_DIR}
+          conda activate firecrown_developer
+        if: steps.cache.outputs.cache-hit != 'true'      
+      - name: Setting up Cobaya
+        shell: bash -l {0}
+        run: python -m pip install cobaya
+        if: steps.cache.outputs.cache-hit != 'true'      
+      - name: Install Smokescreen and test it
+        shell: bash -l {0}
+        run: |
+          cd smokescreen
+          pip install -e .
+          python -m pytest tests/
+
   firecrown-doccheck:
     name: Firecrown Doc check (${{ matrix.os }}, python-${{ matrix.python-version }}, Miniforge)
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,7 @@ jobs:
         with:
           repository: 'lsstdesc/smokescreen'
           path: 'smokescreen'
-          branch: 'fix-updated-firecrown'
-          # Instead of 'branch', 
-          # Use fetch-tag once we have a new release tag to use
+          ref: 'fix-updated-firecrown'
       - name: Setting up Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
## Description

This adds the running of Smokescreen's tests, in their latest tagged version, to Firecrown CI.

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* New workflow job in CI

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
