### PR TITLE
Debugging isitgr loading in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
           ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*
           ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/
           otool -L /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
+          otool -l /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
           python -m isitgr
       - name: Run unit tests with code coverage
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/
           otool -L /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
           otool -l /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
-          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib/python${matrix.python-version}/site-packages/isitgr /Users/runner/miniconda3/envs/firecrown_developer/lib/python${matrix.python-version}/site-packages/isitgr/isitgrlib.so
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python*/site-packages/isitgr/isitgrlib.so
           DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
       - name: Run unit tests with code coverage
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Testing isitgr presence
         shell: bash -l {0}
         run: |
-          ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.11/site-packages/isitgr/
+          ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/
           python -m isitgr
       - name: Run unit tests with code coverage
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
+          ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*
           ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/
+          otool -L /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
           python -m isitgr
       - name: Run unit tests with code coverage
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
           pylint pylint_plugins
           pylint --rcfile tests/pylintrc  tests
           pylint --rcfile examples/pylintrc  examples
+      - name: Testing isitgr presence
+        shell: bash -l {0}
+        run: |
+          ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.11/site-packages/isitgr/
+          python -m isitgr
       - name: Run unit tests with code coverage
         shell: bash -l {0}
         run: python -m pytest -vv --runslow --cov firecrown --cov-report xml --cov-branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           pylint --rcfile tests/pylintrc  tests
           pylint --rcfile examples/pylintrc  examples
       - name: Testing isitgr presence
+        if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
           ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Ensure clear Jupyter Notebooks
         uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1
-      - name: Installing ISITGR
-        shell: bash -l {0}
-        run: |
-          wget https://files.pythonhosted.org/packages/9d/9b/c067d467621aca54b39063bbe2bf3c3d5570928ee8f6e9b916a05cbbf839/isitgr-1.0.5.tar.gz
-          python -m pip install isitgr-1.0.5.tar.gz -v
       - name: Running black check
         shell: bash -l {0}
         run: |
@@ -98,6 +93,7 @@ jobs:
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
           python -c "import isitgr"
       - name: Run unit tests with code coverage
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Ensure clear Jupyter Notebooks
         uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1
+      - name: Installing ISITGR
+        shell: bash -l {0}
+        run: |
+          wget https://files.pythonhosted.org/packages/9d/9b/c067d467621aca54b39063bbe2bf3c3d5570928ee8f6e9b916a05cbbf839/isitgr-1.0.5.tar.gz
+          python -m pip install isitgr-1.0.5.tar.gz -v
       - name: Running black check
         shell: bash -l {0}
         run: |
@@ -93,8 +98,7 @@ jobs:
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
-          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
-          DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
+          python -c "import isitgr"
       - name: Run unit tests with code coverage
         shell: bash -l {0}
         run: python -m pytest -vv --runslow --cov firecrown --cov-report xml --cov-branch
@@ -163,7 +167,8 @@ jobs:
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
-          DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
+          python -c "import isitgr"
       - name: Install Cobaya
         shell: bash -l {0}
         run: python -m pip install cobaya

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,12 @@ jobs:
           conda env config vars set CSL_DIR=${CSL_DIR}
           conda activate firecrown_developer
         if: steps.cache.outputs.cache-hit != 'true'
+      - name: Testing isitgr presence
+        if: ${{ (matrix.os == 'macos') }}
+        shell: bash -l {0}
+        run: |
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
+          DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
       - name: Install Cobaya
         shell: bash -l {0}
         run: python -m pip install cobaya

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/
           otool -L /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
           otool -l /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
-          python -m isitgr
+          DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
       - name: Run unit tests with code coverage
         shell: bash -l {0}
         run: python -m pytest -vv --runslow --cov firecrown --cov-report xml --cov-branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/
           otool -L /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
           otool -l /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib/python${matrix.python-version}/site-packages/isitgr /Users/runner/miniconda3/envs/firecrown_developer/lib/python${matrix.python-version}/site-packages/isitgr/isitgrlib.so
           DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
       - name: Run unit tests with code coverage
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,6 @@ jobs:
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
-          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
           DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
       - name: Install Cobaya
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,7 @@ jobs:
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
-          ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*
-          ls -lasth /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/
-          otool -L /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
-          otool -l /Users/runner/miniconda3/envs/firecrown_developer/lib/python3*/site-packages/isitgr/*.so
-          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python*/site-packages/isitgr/isitgrlib.so
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
           DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_APIS=1 python -c "import isitgr"
       - name: Run unit tests with code coverage
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,11 @@ jobs:
           pylint pylint_plugins
           pylint --rcfile tests/pylintrc  tests
           pylint --rcfile examples/pylintrc  examples
-      - name: Testing isitgr presence
+      - name: Remove redundant rpath and import isitgr
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
-          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so || true
           python -c "import isitgr"
       - name: Run unit tests with code coverage
         shell: bash -l {0}
@@ -159,11 +159,11 @@ jobs:
           conda env config vars set CSL_DIR=${CSL_DIR}
           conda activate firecrown_developer
         if: steps.cache.outputs.cache-hit != 'true'
-      - name: Testing isitgr presence
+      - name: Remove redundant rpath and import isitgr
         if: ${{ (matrix.os == 'macos') }}
         shell: bash -l {0}
         run: |
-          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so
+          install_name_tool -delete_rpath /Users/runner/miniconda3/envs/firecrown_developer/lib /Users/runner/miniconda3/envs/firecrown_developer/lib/python3.1?/site-packages/isitgr/isitgrlib.so || true
           python -c "import isitgr"
       - name: Install Cobaya
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -33,6 +33,7 @@ dependencies:
   - pip >= 20.1  # pip is needed as dependency
   - pip:
     - cobaya
+    - isitgr
     - pygobject-stubs
   - plotnine
   - portalocker

--- a/environment.yml
+++ b/environment.yml
@@ -32,9 +32,7 @@ dependencies:
   - numpy >= 1.25.0
   - pip >= 20.1  # pip is needed as dependency
   - pip:
-    - --no-binary=isitgr
     - cobaya
-    - isitgr
     - pygobject-stubs
   - plotnine
   - portalocker

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - numpy >= 1.25.0
   - pip >= 20.1  # pip is needed as dependency
   - pip:
+    - --no-binary=isitgr
     - cobaya
     - isitgr
     - pygobject-stubs


### PR DESCRIPTION
## Description

The `isitgr` package fails to load on macOS runs due to duplicated RPATH entries in its binary. This PR applies the necessary steps to remove the extra entry. The issue appears to occur only on CI, as we could not reproduce it locally.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
