### PR TITLE
Alter test to avoid mypy error

### DIFF
--- a/tests/metadata/test_metadata_two_point_types.py
+++ b/tests/metadata/test_metadata_two_point_types.py
@@ -66,8 +66,8 @@ def test_order_enums():
 
 
 def test_galaxies_is_shear():
-    assert Galaxies.PART_OF_XI_MINUS is Galaxies.SHEAR_MINUS
-    assert Galaxies.PART_OF_XI_PLUS is Galaxies.SHEAR_PLUS
+    assert Galaxies.PART_OF_XI_MINUS == Galaxies.SHEAR_MINUS
+    assert Galaxies.PART_OF_XI_PLUS == Galaxies.SHEAR_PLUS
     assert Galaxies.SHEAR_E.is_shear()
     assert Galaxies.SHEAR_T.is_shear()
     assert Galaxies.PART_OF_XI_MINUS.is_shear()


### PR DESCRIPTION
## Description

mypy 1.18.1 is complaining about comparison of Enum aliases using `is`.
The use of `is` is actually correct, but since mypy is now complaining about it, this PR changes the test to use `==` instead.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
