### PR TITLE
First version of BinRule class system for bin combinations.

### DIFF
--- a/tests/metadata/test_metadata_two_point_types.py
+++ b/tests/metadata/test_metadata_two_point_types.py
@@ -389,14 +389,14 @@ def test_match_name_type_convention3():
 def test_match_name_type_require_convention_fail():
     with pytest.raises(
         ValueError,
-        match="Invalid tracer names (.*) do not respect the naming convetion.",
+        match="Invalid tracer names (.*) do not respect the naming convention.",
     ):
         match_name_type(
             "no_convention",
             "here_too",
             Galaxies.COUNTS,
             Galaxies.SHEAR_T,
-            require_convetion=True,
+            require_convention=True,
         )
 
 
@@ -406,7 +406,7 @@ def test_match_name_type_require_convention_lens():
         "lens0",
         Galaxies.COUNTS,
         Galaxies.COUNTS,
-        require_convetion=True,
+        require_convention=True,
     )
     assert not match
     assert n1 == "lens0"
@@ -421,7 +421,7 @@ def test_match_name_type_require_convention_source():
         "src0",
         Galaxies.PART_OF_XI_MINUS,
         Galaxies.PART_OF_XI_MINUS,
-        require_convetion=True,
+        require_convention=True,
     )
     assert not match
     assert n1 == "src0"


### PR DESCRIPTION
## Description

This PR introduces a framework for bin pair selection in two-point correlation functions through a hierarchy of `BinRule` classes. The design allows users to define, combine, and reuse rules for filtering `InferredGalaxyZDist` bins and their measurements before constructing `TwoPointXY` objects. This addresses the need to systematically and safely generate physically meaningful combinations, beyond simple “all compatible pairs”. There are example in `tests/metadata/test_metadata_two_point_sacc.py`

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* New feature (non-breaking change which adds functionality)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [ ] I have run `bash pre-commit-check` and fixed any issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
