### PR TITLE
Require sacc 2.1 or newer

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - quarto
   - requests
   - rich
-  - sacc >= 0.11
+  - sacc >= 2.1
   - scipy
   - sphinx
   - sphinx-autoapi


### PR DESCRIPTION
## Description

This PR moves us to a newer version of Sacc, to get a fix for a bug that prevents writing FITS-format Sacc files containing large covariance matrices (with more than 999 columns).

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
