### PR TITLE
Fix failing ci

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,8 @@ dependencies:
   - pytest-cov
   - pytest-json-report
   - pytest-xdist
-  - python >= 3.11
+  # Python version is controlled by setup-miniconda action in CI
+  # - python >= 3.11
   - pyyaml
   - quarto
   - requests


### PR DESCRIPTION
## Description

This changes the ci.yml' use of caching to avoid a bug that can cause the CI to load a cache built with the wrong python version.

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
