### PR TITLE
Temporarily pin numpy to less than version 2.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - more-itertools
   - mypy
   - numcosmo >= 0.21.1
-  - numpy >= 2.0
+  - numpy >= 2.0, < 2.4
   - pip >= 20.1  # pip is needed as dependency
   - pip:
     - cobaya


### PR DESCRIPTION
## Description

This PR will pin the version of `numpy` to be < 2.4.
Version 2.4 of numpy removes the long-deprecated `numpy.trap` function, which breaks Firecrown CI, because of `fast-pt` using that function.
Until `fast-pt` is updated, we have to restrict our version of `numpy`.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [ ] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
