### PR TITLE
Fix test target and integration opt-in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To maintain high code quality and consistency, we use several automated tools. W
 | :--- | :--- | :--- |
 | `make format` | Automatically format all code using `black` | Frequently during development |
 | `make lint` | Run all linters (`black`, `flake8`, `mypy`, `pylint`) in parallel | Before every commit |
-| `make test` | Run fast unit tests in parallel | Regularly during development |
+| `make test` | Run unit tests in parallel with coverage reporting | Regularly during development |
 | `make unit-tests` | Run all unit tests with 100% per-component coverage check | Before pushing |
 | `make test-ci` | Run the full test suite exactly as the CI system does | Final check before pushing |
 | `make docs` | Build and verify all documentation (tutorials + API) | When changing tutorials or docstrings |
@@ -50,6 +50,7 @@ graph TD
     
     pre-commit["make pre-commit"]:::main
     test-ci["make test-ci"]:::main
+    test-all["make test-all"]:::main
     docs["make docs"]:::main
     unit-tests["make unit-tests"]:::main
     
@@ -65,6 +66,12 @@ graph TD
     test-ci --> test-slow["make test-slow"]
     test-ci --> test-integration["make test-integration"]
     test-ci --> test-example["make test-example"]
+    
+    %% Test-all dependencies
+    test-all --> test["make test\n(+coverage)"]
+    test-all --> test-slow
+    test-all --> test-integration
+    test-all --> test-example
     
     %% Test coverage dependencies
     test-all-coverage --> unit-tests-core["unit-tests-core"]
@@ -147,6 +154,13 @@ graph TD
     barrier -.->|then parallel| test-slow["test-slow<br/>(pytest -n auto)"]:::pytest
     barrier -.->|then parallel| test-int["test-integration"]:::sequential
     barrier -.->|then parallel| test-ex["test-example"]:::sequential
+    
+    %% Test-all parallelism
+    test-all["make test-all<br/>(parallel)"]:::parallel
+    test-all --> test-run["test<br/>(pytest -n auto<br/>+coverage)"]:::pytest
+    test-all --> test-slow
+    test-all --> test-int
+    test-all --> test-ex
     
     %% Unit tests post parallelism
     test-all-cov --> unit-post["unit-tests-post<br/>(parallel)"]:::parallel

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: help format lint typecheck test test-coverage test-example test-integration test-slow \
+.PHONY: help format lint typecheck test test-example test-integration test-slow \
 	test-all clean clean-docs clean-coverage docs tutorials api-docs docs-build \
 	lint-black lint-flake8 lint-pylint lint-pylint-firecrown lint-pylint-plugins \
 	lint-pylint-tests lint-pylint-examples lint-mypy pre-commit install all-checks \
@@ -71,7 +71,7 @@ help:  ## Show common developer targets
 	@echo "During development:"
 	@echo "  make format          - Auto-format code (run frequently)"
 	@echo "  make lint            - Check code quality (before commit)"
-	@echo "  make test            - Run fast tests (during development)"
+	@echo "  make test            - Run tests with coverage (during development)"
 	@echo ""
 	@echo "Before committing:"
 	@echo "  make unit-tests      - Verify 100% coverage on changed modules"
@@ -95,7 +95,7 @@ help-all:  ## Show this help message
 	@echo "Common workflows:"
 	@echo "  make format          - Format all code with black"
 	@echo "  make lint            - Run all linting tools (parallel by default)"
-	@echo "  make test            - Run fast tests (parallel by default)"
+	@echo "  make test            - Run tests with coverage (parallel by default)"
 	@echo "  make unit-tests      - Run all unit tests with 100% coverage check"
 	@echo "  make test-ci         - Run the full CI suite (all tests, slow, examples)"
 	@echo "  make docs            - Build and verify all documentation (tutorials + API)"
@@ -162,10 +162,7 @@ typecheck: lint-mypy  ## Alias for mypy type checking
 
 ##@ Testing
 
-test:  ## Run tests in parallel (fast, no --runslow)
-	$(PYTEST_PARALLEL) $(PYTEST_DURATIONS)
-
-test-coverage:  ## Run tests with coverage reporting
+test:  ## Run tests in parallel with coverage reporting
 	$(RM) $(COVERAGE_JSON)
 	$(RM) -r $(HTMLCOV_DIR)
 	$(PYTEST_PARALLEL) $(PYTEST_DURATIONS) $(PYTEST_COV_FLAGS)
@@ -190,7 +187,7 @@ test-example:  ## Run example tests only
 	fi
 
 test-integration:  ## Run integration tests only
-	$(PYTEST) -v -s -m integration tests/integration
+	$(PYTEST) -v -s --runintegration -m integration tests/integration
 
 test-all: test-slow test-example test-integration test  ## Run all tests (slow + example + integration)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,7 @@ def pytest_addoption(parser):
 
     --runslow: used to run tests marked as slow, which are otherwise not run.
     --example: used to run only example tests, which are otherwise not run.
+    --runintegration: used to run tests marked as integration, which are otherwise not run.
     """
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
@@ -100,6 +101,12 @@ def pytest_addoption(parser):
         default=False,
         help="run example tests",
     )
+    parser.addoption(
+        "--runintegration",
+        action="store_true",
+        default=False,
+        help="run integration tests",
+    )
 
 
 def pytest_configure(config):
@@ -108,6 +115,10 @@ def pytest_configure(config):
     Use the marker `slow` for any test that takes more than a second to run.
     Tests marked as `slow` are not run unless the user requests them by specifying
     the --runslow flag to the pytest program.
+
+    Use the marker `integration` for tests that verify independent units work together.
+    Tests marked as `integration` are not run unless the user requests them by
+    specifying the --runintegration flag to the pytest program.
     """
     config.addinivalue_line("markers", "slow: mark test as slow to run")
 
@@ -120,6 +131,9 @@ def pytest_collection_modifyitems(config, items):
 
     if not config.getoption("--runslow"):
         _skip_tests(items, "slow", "need --runslow option to run")
+
+    if not config.getoption("--runintegration"):
+        _skip_tests(items, "integration", "need --runintegration option to run")
 
 
 def _skip_tests(items, keyword, reason):


### PR DESCRIPTION
## Description

This PR does some improvement of the Makefile to streamline the development workflow.

Add --runintegration pytest option so that tests marked with the integration marker are skipped by default, consistent with the existing --runslow and --example behavior. Update the test-integration Makefile target to pass this flag.

Remove the test-coverage target and merge its coverage- reporting behavior directly into the test target, making coverage collection the default for all test runs.

Update all documentation (CONTRIBUTING.md, Makefile help text, copilot-instructions.md, testing_protocol, and auto_testing instructions) to reflect these changes.

## Type of change

* Refactoring, only of Makefile and related documentation and testing configuration,

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [ ] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
