### PR TITLE
Normalize window option

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -86,7 +86,7 @@ jobs:
           echo "env_hash=${h}" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Conda env
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: ${{ env.CONDA }}/envs
@@ -98,7 +98,7 @@ jobs:
           conda env update -n ${{ env.CONDA_ENV }} -f env_tmp.yml --prune
       - name: Save conda environment
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.CONDA }}/envs
           key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -148,7 +148,7 @@ jobs:
           echo "env_hash=${h}" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Conda env
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: ${{ env.CONDA }}/envs
@@ -179,7 +179,7 @@ jobs:
       - name: Save conda-forge, CosmoSIS and Cobaya environment
         if: steps.cache.outputs.cache-hit != 'true'
         id: cache-primes-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.CONDA }}/envs
           key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -247,7 +247,7 @@ jobs:
           echo "env_hash=${h}" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Conda env
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: ${{ env.CONDA }}/envs
@@ -277,7 +277,7 @@ jobs:
       - name: Save conda-forge, CosmoSIS and Cobaya environment
         if: steps.cache.outputs.cache-hit != 'true'
         id: cache-primes-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.CONDA }}/envs
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - alabaster
   - babel
-  - black = 25.12.0
+  - black
   - charset-normalizer
   - clmm
   - compilers

--- a/examples/cluster_number_counts/generate_rich_mean_mass_sacc_data_withshear.py
+++ b/examples/cluster_number_counts/generate_rich_mean_mass_sacc_data_withshear.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 """Function to generate a SACC file for cluster number counts and cluster DeltaSigma."""
+
 import os
 from typing import Tuple
 

--- a/firecrown/app/examples/_des_y1_3x2pt.py
+++ b/firecrown/app/examples/_des_y1_3x2pt.py
@@ -183,31 +183,22 @@ two_point_factory:
 """
 
         if self.factory_type == DESY1FactoryType.YAML_PURE_CCL:
-            return (
-                base_config
-                + """
+            return base_config + """
 ccl_factory:
   creation_mode: 'pure_ccl_mode'
   require_nonlinear_pk: true
 """
-            )
         if self.factory_type == DESY1FactoryType.YAML_MU_SIGMA:
-            return (
-                base_config
-                + """
+            return base_config + """
 ccl_factory:
   creation_mode: 'mu_sigma_isitgr'
   require_nonlinear_pk: true
 """
-            )
 
-        return (
-            base_config
-            + """
+        return base_config + """
 ccl_factory:
   require_nonlinear_pk: true
 """
-        )
 
     def get_build_parameters(self, sacc_path: Path) -> NamedParameters:
         """Return build parameters for likelihood construction.

--- a/firecrown/app/sacc/_utils.py
+++ b/firecrown/app/sacc/_utils.py
@@ -8,7 +8,6 @@ from scipy.interpolate import PchipInterpolator
 
 from firecrown import metadata_types as mdt
 
-
 QuadOpts = TypedDict(
     "QuadOpts",
     {

--- a/firecrown/data_functions/_extraction.py
+++ b/firecrown/data_functions/_extraction.py
@@ -18,8 +18,16 @@ def extract_all_harmonic_data(
     sacc_data: sacc.Sacc,
     allow_mixed_types: bool = False,
     allowed_data_type: None | list[str] = None,
+    normalize: bool = True,
 ) -> list[TwoPointMeasurement]:
-    """Extract the two-point function metadata and data from a sacc file."""
+    """Extract the two-point function metadata and data from a sacc file.
+
+    :param sacc_data: The SACC file containing the data.
+    :param allow_mixed_types: Whether to allow mixed tracer types.
+    :param allowed_data_type: List of allowed data types to extract.
+    :param normalize: If True, normalize the window function weights to sum to 1.
+    :return: A list of TwoPointMeasurement objects.
+    """
     if sacc_data.covariance is None or sacc_data.covariance.dense is None:
         raise ValueError("The SACC object does not have a dense covariance matrix.")
 
@@ -41,7 +49,9 @@ def extract_all_harmonic_data(
             data_type=dt, tracer1=t1, tracer2=t2, return_cov=False, return_ind=True
         )
 
-        ells, weights, window_ells = maybe_enforce_window(ells, indices, sacc_data)
+        ells, weights, window_ells = maybe_enforce_window(
+            ells, indices, sacc_data, normalize
+        )
 
         result.append(
             TwoPointMeasurement(

--- a/firecrown/fctools/code_block_checker.py
+++ b/firecrown/fctools/code_block_checker.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-
 app = typer.Typer()
 
 

--- a/firecrown/fctools/symbol_reference_checker.py
+++ b/firecrown/fctools/symbol_reference_checker.py
@@ -21,7 +21,6 @@ from firecrown.fctools.docs_helpers import (
     print_success,
 )
 
-
 app = typer.Typer()
 
 

--- a/firecrown/likelihood/_base.py
+++ b/firecrown/likelihood/_base.py
@@ -44,7 +44,6 @@ from firecrown.updatable import (
     register_new_updatable_parameter,
 )
 
-
 # ============================================================================
 # Classes from _likelihood.py
 # ============================================================================

--- a/firecrown/likelihood/_two_point.py
+++ b/firecrown/likelihood/_two_point.py
@@ -723,8 +723,10 @@ def read_reals(
     :param sacc_data: The SACC data object to be read.
     :return: The theta and xi values.
     """
+    tracers = theory.sacc_tracers
+    assert tracers is not None
     thetas, xis = sacc_data.get_theta_xi(
-        theory.sacc_data_type, *theory.sacc_tracers, return_cov=False
+        theory.sacc_data_type, *tracers, return_cov=False
     )
     # As version 0.13 of sacc, the method get_real returns the
     # theta values and the xi values in arrays of the same length.
@@ -733,9 +735,7 @@ def read_reals(
     common_length = len(thetas)
     if common_length == 0:
         return None
-    sacc_indices = np.atleast_1d(
-        sacc_data.indices(theory.sacc_data_type, theory.sacc_tracers)
-    )
+    sacc_indices = np.atleast_1d(sacc_data.indices(theory.sacc_data_type, tracers))
     assert sacc_indices is not None  # Needed for mypy
     assert len(sacc_indices) == common_length
     return thetas, xis, sacc_indices
@@ -754,6 +754,7 @@ def read_ell_cells(
     :return: The ell and Cell values.
     """
     tracers = theory.sacc_tracers
+    assert tracers is not None
     ells, cells = sacc_data.get_ell_cl(
         theory.sacc_data_type, *tracers, return_cov=False
     )

--- a/firecrown/likelihood/_two_point.py
+++ b/firecrown/likelihood/_two_point.py
@@ -194,6 +194,7 @@ class TwoPoint(Statistic):
         tracers: None | TracerNames = None,
         int_options: ClIntegrationOptions | None = None,
         apply_interp: ApplyInterpolationWhen = ApplyInterpolationWhen.DEFAULT,
+        normalize_window: bool = True,
     ) -> None:
         super().__init__()
         self.theory = TwoPointTheory(
@@ -206,6 +207,7 @@ class TwoPoint(Statistic):
             apply_interp=apply_interp,
         )
         self._data: None | DataVector = None
+        self.normalize_window = normalize_window
 
     @classmethod
     def from_metadata_index(
@@ -460,7 +462,9 @@ class TwoPoint(Statistic):
                 )
             replacement_ells: None | npt.NDArray[np.int64]
             window: None | npt.NDArray[np.float64]
-            replacement_ells, window = extract_window_function(sacc_data, sacc_indices)
+            replacement_ells, window = extract_window_function(
+                sacc_data, sacc_indices, self.normalize_window
+            )
             if window is not None:
                 # When using a window function, we do not calculate all Cl's.
                 # For this reason we have a default set of ells that we use

--- a/firecrown/likelihood/factories/_models.py
+++ b/firecrown/likelihood/factories/_models.py
@@ -30,10 +30,10 @@ def _build_two_point_likelihood_harmonic(
 ):
     """Build a likelihood object for two-point statistics in harmonic space.
 
-    This function creates a likelihood object for two-point statistics in harmonic space
-    using a SACC file and a set of statistic factories. The user must provide the SACC
-    file and specify which statistic factories to use. The likelihood object is created
-    by combining the SACC file with the specified statistic factories.
+    This function creates a likelihood object for two-point statistics in harmonic
+    space using a SACC file and a set of statistic factories. The user must provide the
+    SACC file and specify which statistic factories to use. The likelihood object is
+    created by combining the SACC file with the specified statistic factories.
 
     :param sacc_data: The SACC file containing the data.
     :param two_point_factory: The two-point statistic factory.

--- a/firecrown/likelihood/factories/_models.py
+++ b/firecrown/likelihood/factories/_models.py
@@ -36,8 +36,8 @@ def _build_two_point_likelihood_harmonic(
     by combining the SACC file with the specified statistic factories.
 
     :param sacc_data: The SACC file containing the data.
-    :param wl_factory: The weak lensing statistic factory.
-    :param nc_factory: The number counts statistic factory.
+    :param two_point_factory: The two-point statistic factory.
+    :param filters: Optional filters to apply to the two-point measurements.
     :param normalize: If True, normalize the window function weights to sum to 1.
 
     :return: A likelihood object for two-point statistics in harmonic space.

--- a/firecrown/likelihood/factories/_models.py
+++ b/firecrown/likelihood/factories/_models.py
@@ -26,6 +26,7 @@ def _build_two_point_likelihood_harmonic(
     sacc_data: sacc.Sacc,
     two_point_factory: TwoPointFactory,
     filters: TwoPointBinFilterCollection | None = None,
+    normalize: bool = True,
 ):
     """Build a likelihood object for two-point statistics in harmonic space.
 
@@ -37,10 +38,11 @@ def _build_two_point_likelihood_harmonic(
     :param sacc_data: The SACC file containing the data.
     :param wl_factory: The weak lensing statistic factory.
     :param nc_factory: The number counts statistic factory.
+    :param normalize: If True, normalize the window function weights to sum to 1.
 
     :return: A likelihood object for two-point statistics in harmonic space.
     """
-    tpms = extract_all_harmonic_data(sacc_data)
+    tpms = extract_all_harmonic_data(sacc_data, normalize=normalize)
     if len(tpms) == 0:
         raise ValueError(
             "No two-point measurements in harmonic space found in the SACC file."
@@ -95,6 +97,7 @@ class DataSourceSacc(BaseModel):
 
     sacc_data_file: str
     filters: TwoPointBinFilterCollection | None = None
+    normalize_window: bool = True
     _path: Path | None = None
 
     def set_path(self, path: Path) -> None:
@@ -169,7 +172,10 @@ class TwoPointExperiment(BaseModel):
                 )
             case TwoPointCorrelationSpace.HARMONIC:
                 likelihood = _build_two_point_likelihood_harmonic(
-                    sacc_data, self.two_point_factory, filters=self.data_source.filters
+                    sacc_data,
+                    self.two_point_factory,
+                    filters=self.data_source.filters,
+                    normalize=self.data_source.normalize_window,
                 )
             case _ as unreachable:
                 assert_never(unreachable)

--- a/firecrown/likelihood/number_counts/_source.py
+++ b/firecrown/likelihood/number_counts/_source.py
@@ -25,7 +25,6 @@ from firecrown.updatable import (
     UpdatableCollection,
 )
 
-
 NUMBER_COUNTS_DEFAULT_BIAS = 1.5
 
 

--- a/firecrown/metadata_functions/_extraction.py
+++ b/firecrown/metadata_functions/_extraction.py
@@ -468,6 +468,8 @@ def extract_all_harmonic_metadata(
     :param sacc_data: The SACC object containing tracers and data points.
     :param allowed_data_type: Optional list of SACC data type strings to include.
         If None, all harmonic-space data types are extracted.
+    :param allow_mixed_types: If True, allow extraction when tracers contain mixed
+        measurement types; otherwise require consistent tracer measurement typing.
     :param bin_pair_selector: Optional selector to filter which bin pairs to include.
         If None, all valid bin pairs are returned.
     :param normalize: If True, normalize the window function weights to sum to 1.
@@ -601,10 +603,10 @@ def extract_window_function(
 ) -> tuple[None | npt.NDArray[np.int64], None | npt.NDArray[np.float64]]:
     """Extract ells and weights for a window function.
 
-    :params sacc_data: the Sacc object from which we read.
-    :params indices: the indices of the data points in the Sacc object which
+    :param sacc_data: the Sacc object from which we read.
+    :param indices: the indices of the data points in the Sacc object which
         are computed by the window function.
-    :params normalize: if True, normalize the window function weights to sum to 1.
+    :param normalize: if True, normalize the window function weights to sum to 1.
     :return: the ells and weights of the window function that match the
        given indices from a sacc object, or a tuple of (None, None)
        if the indices represent the measured Cells directly.
@@ -649,7 +651,9 @@ def maybe_enforce_window(
     :param indices: The indices of the data points in the SACC object.
     :param sacc_data: The SACC object containing the data.
     :param normalize: if True, normalize the window function weights to sum to 1.
-    :return: A tuple containing the possibly replaced ells and the window weights.
+    :return: A tuple containing the possibly replaced ells, the window weights, and
+        `window_ells`, the original ell grid used by the window (or None if no window
+        function is applied).
     """
     replacement_ells, weights = extract_window_function(sacc_data, indices, normalize)
     if replacement_ells is not None:

--- a/firecrown/metadata_functions/_extraction.py
+++ b/firecrown/metadata_functions/_extraction.py
@@ -635,9 +635,7 @@ def maybe_enforce_window(
     :param normalize: if True, normalize the window function weights to sum to 1.
     :return: A tuple containing the possibly replaced ells and the window weights.
     """
-    replacement_ells, weights = extract_window_function(
-        sacc_data, indices, normalize
-    )
+    replacement_ells, weights = extract_window_function(sacc_data, indices, normalize)
     if replacement_ells is not None:
         window_ells = ells
         ells = replacement_ells

--- a/firecrown/metadata_functions/_extraction.py
+++ b/firecrown/metadata_functions/_extraction.py
@@ -593,13 +593,14 @@ def extract_all_photoz_bin_combinations(
 
 
 def extract_window_function(
-    sacc_data: sacc.Sacc, indices: npt.NDArray[np.int64]
+    sacc_data: sacc.Sacc, indices: npt.NDArray[np.int64], normalize: bool = True
 ) -> tuple[None | npt.NDArray[np.int64], None | npt.NDArray[np.float64]]:
     """Extract ells and weights for a window function.
 
     :params sacc_data: the Sacc object from which we read.
     :params indices: the indices of the data points in the Sacc object which
         are computed by the window function.
+    :params normalize: if True, normalize the window function weights to sum to 1.
     :return: the ells and weights of the window function that match the
        given indices from a sacc object, or a tuple of (None, None)
        if the indices represent the measured Cells directly.
@@ -613,21 +614,30 @@ def extract_window_function(
     if bandpower_window is None:
         return None, None
     ells = bandpower_window.values
-    weights = bandpower_window.weight / bandpower_window.weight.sum(axis=0)
+    if normalize:
+        weights = bandpower_window.weight / bandpower_window.weight.sum(axis=0)
+    else:
+        weights = bandpower_window.weight
     return ells, weights
 
 
 def maybe_enforce_window(
-    ells: npt.NDArray, indices: npt.NDArray[np.int64], sacc_data: sacc.Sacc
+    ells: npt.NDArray,
+    indices: npt.NDArray[np.int64],
+    sacc_data: sacc.Sacc,
+    normalize: bool = True,
 ) -> tuple[npt.NDArray[np.int64], None | npt.NDArray[np.float64], None | npt.NDArray]:
     """Possibly enforce a window function on the given ells.
 
     :param ells: The original ell values.
     :param indices: The indices of the data points in the SACC object.
     :param sacc_data: The SACC object containing the data.
+    :param normalize: if True, normalize the window function weights to sum to 1.
     :return: A tuple containing the possibly replaced ells and the window weights.
     """
-    replacement_ells, weights = extract_window_function(sacc_data, indices)
+    replacement_ells, weights = extract_window_function(
+        sacc_data, indices, normalize
+    )
     if replacement_ells is not None:
         window_ells = ells
         ells = replacement_ells

--- a/firecrown/metadata_functions/_extraction.py
+++ b/firecrown/metadata_functions/_extraction.py
@@ -608,6 +608,7 @@ def extract_window_function(
     :return: the ells and weights of the window function that match the
        given indices from a sacc object, or a tuple of (None, None)
        if the indices represent the measured Cells directly.
+    :raises ValueError: if any window function column has zero total weight.
     """
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -618,8 +619,19 @@ def extract_window_function(
     if bandpower_window is None:
         return None, None
     ells = bandpower_window.values
+
+    # Check for zero-weight columns
+    weight_sums = bandpower_window.weight.sum(axis=0)
+    zero_weight_indices = np.where(np.isclose(weight_sums, 0.0))[0]
+    if len(zero_weight_indices) > 0:
+        raise ValueError(
+            f"Window function has zero total weight for column(s) at index/indices: "
+            f"{zero_weight_indices.tolist()}. Each window function column must have "
+            f"non-zero total weight."
+        )
+
     if normalize:
-        weights = bandpower_window.weight / bandpower_window.weight.sum(axis=0)
+        weights = bandpower_window.weight / weight_sums
     else:
         weights = bandpower_window.weight
     return ells, weights

--- a/firecrown/metadata_functions/_extraction.py
+++ b/firecrown/metadata_functions/_extraction.py
@@ -461,6 +461,7 @@ def extract_all_harmonic_metadata(
     allowed_data_type: None | list[str] = None,
     allow_mixed_types: bool = False,
     bin_pair_selector: None | mdt.BinPairSelector = None,
+    normalize: bool = True,
 ) -> list[mdt.TwoPointHarmonic]:
     """Extract two-point harmonic-space metadata and data from a SACC file.
 
@@ -469,6 +470,7 @@ def extract_all_harmonic_metadata(
         If None, all harmonic-space data types are extracted.
     :param bin_pair_selector: Optional selector to filter which bin pairs to include.
         If None, all valid bin pairs are returned.
+    :param normalize: If True, normalize the window function weights to sum to 1.
     :return: List of TwoPointHarmonic objects with metadata and ell values.
     """
     inferred_galaxy_zdists_dict = {
@@ -501,7 +503,9 @@ def extract_all_harmonic_metadata(
             return_cov=False,
             return_ind=True,
         )
-        ells, weights, window_ells = maybe_enforce_window(ells, indices, sacc_data)
+        ells, weights, window_ells = maybe_enforce_window(
+            ells, indices, sacc_data, normalize
+        )
 
         result.append(
             mdt.TwoPointHarmonic(

--- a/firecrown/updatable/_collection.py
+++ b/firecrown/updatable/_collection.py
@@ -12,7 +12,6 @@ from firecrown.updatable._base import Updatable
 from firecrown.updatable._records import UpdatableUsageRecord
 from firecrown.updatable._types import UpdatableProtocol
 
-
 T = TypeVar("T", bound=Updatable)
 
 

--- a/tests/app/analysis/test_analysis_builder.py
+++ b/tests/app/analysis/test_analysis_builder.py
@@ -90,8 +90,7 @@ class TestAnalysisBuilderInitialization:
         """Test initialization with custom cosmology specification."""
         # Create a cosmology spec file
         cosmo_file = tmp_path / "cosmology.yaml"
-        cosmo_file.write_text(
-            r"""
+        cosmo_file.write_text(r"""
 name: test_cosmology
 description: Test cosmology
 parameters:
@@ -155,8 +154,7 @@ parameters:
     upper_bound: 1.0
     default_value: 0.0
     free: false
-"""
-        )
+""")
 
         with patch.object(ConcreteAnalysisBuilder, "_proceed_generation"):
             builder = ConcreteAnalysisBuilder(

--- a/tests/app/analysis/test_numcosmo_generator.py
+++ b/tests/app/analysis/test_numcosmo_generator.py
@@ -48,8 +48,7 @@ def fixture_minimal_factory_file(tmp_path: Path) -> Path:
     - Mock SACC data with 3 data points
     """
     factory_file = tmp_path / "factory.py"
-    factory_file.write_text(
-        """
+    factory_file.write_text("""
 import sacc
 import numpy as np
 from firecrown.likelihood.number_counts import NumberCounts
@@ -77,8 +76,7 @@ def build_likelihood(_):
     likelihood = ConstGaussian(statistics=statistics)
     likelihood.read(sacc_data)
     return likelihood
-""".strip()
-    )
+""".strip())
     return factory_file
 
 

--- a/tests/app/analysis/test_numcosmo_integration.py
+++ b/tests/app/analysis/test_numcosmo_integration.py
@@ -43,8 +43,7 @@ def fixture_minimal_factory_file(tmp_path: Path) -> Path:
     - Mock SACC data with 3 data points
     """
     factory_file = tmp_path / "factory.py"
-    factory_file.write_text(
-        """
+    factory_file.write_text("""
 import sacc
 import numpy as np
 from firecrown.likelihood.number_counts import NumberCounts
@@ -72,8 +71,7 @@ def build_likelihood(_):
     likelihood = ConstGaussian(statistics=statistics)
     likelihood.read(sacc_data)
     return likelihood
-""".strip()
-    )
+""".strip())
     return factory_file
 
 

--- a/tests/app/sacc/test_view.py
+++ b/tests/app/sacc/test_view.py
@@ -19,7 +19,6 @@ from firecrown.app.sacc._handlers import (
     UnknownWarningHandler,
 )
 
-
 # pylint: disable=too-many-lines
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,6 @@ import firecrown.likelihood._two_point as tp
 import firecrown.likelihood._cmb as cmb
 from firecrown.metadata_types import Clusters, CMB
 
-
 # Helper function for creating AST ClassDef nodes across Python versions
 if sys.version_info >= (3, 12):
 

--- a/tests/fctools/test_code_block_checker.py
+++ b/tests/fctools/test_code_block_checker.py
@@ -10,7 +10,6 @@ from typer.testing import CliRunner
 
 from firecrown.fctools.code_block_checker import check_qmd_file, app
 
-
 # Create CliRunner instance for testing
 runner = CliRunner()
 

--- a/tests/fctools/test_common.py
+++ b/tests/fctools/test_common.py
@@ -150,14 +150,12 @@ class TestImportModuleFromFile:
     def test_import_valid_module(self, tmp_path, console):
         """Test importing a valid Python module from a file."""
         module_file = tmp_path / "test_module.py"
-        module_file.write_text(
-            """
+        module_file.write_text("""
 def test_function():
     return 42
 
 TEST_CONSTANT = "hello"
-"""
-        )
+""")
 
         module = import_module_from_file(console, module_file)
 

--- a/tests/fctools/test_generate_symbol_map.py
+++ b/tests/fctools/test_generate_symbol_map.py
@@ -20,7 +20,6 @@ from firecrown.fctools.generate_symbol_map import (
     app,
 )
 
-
 # Test fixtures - create some mock objects
 
 

--- a/tests/fctools/test_symbol_reference_checker.py
+++ b/tests/fctools/test_symbol_reference_checker.py
@@ -9,7 +9,6 @@ from firecrown.fctools.symbol_reference_checker import (
     app,
 )
 
-
 # Create CliRunner instance for testing
 runner = CliRunner()
 
@@ -48,13 +47,11 @@ def test_check_qmd_file_valid_symbols(tmp_path):
     """Test checking a file with valid symbol references."""
     # Create a test .qmd file
     qmd_file = tmp_path / "test.qmd"
-    qmd_file.write_text(
-        """
+    qmd_file.write_text("""
 # Test file
 
 This mentions `firecrown.parameters.Parameter` and `Updatable`.
-"""
-    )
+""")
 
     # Create a symbol map with these symbols
     symbol_map = {
@@ -69,11 +66,9 @@ This mentions `firecrown.parameters.Parameter` and `Updatable`.
 def test_check_qmd_file_invalid_fully_qualified(tmp_path):
     """Test checking a file with invalid fully-qualified symbol."""
     qmd_file = tmp_path / "test.qmd"
-    qmd_file.write_text(
-        """
+    qmd_file.write_text("""
 This mentions `firecrown.parameters.Paramater` (typo).
-"""
-    )
+""")
 
     symbol_map = {
         "firecrown.parameters.Parameter": "api/...",
@@ -88,11 +83,9 @@ This mentions `firecrown.parameters.Paramater` (typo).
 def test_check_qmd_file_invalid_unqualified(tmp_path):
     """Test checking a file with invalid unqualified symbol."""
     qmd_file = tmp_path / "test.qmd"
-    qmd_file.write_text(
-        """
+    qmd_file.write_text("""
 This mentions `Updateable` (typo, should be Updatable).
-"""
-    )
+""")
 
     symbol_map = {
         "firecrown.updatable.Updatable": "api/...",
@@ -106,13 +99,11 @@ This mentions `Updateable` (typo, should be Updatable).
 def test_check_qmd_file_multiple_errors(tmp_path):
     """Test that all errors are reported, not just the first."""
     qmd_file = tmp_path / "test.qmd"
-    qmd_file.write_text(
-        """
+    qmd_file.write_text("""
 Line 1 has `firecrown.invalid.Class1`
 Line 2 has `firecrown.invalid.Class2`
 Line 3 has `InvalidClass3`
-"""
-    )
+""")
 
     symbol_map = {
         "firecrown.valid.Something": "api/...",
@@ -128,12 +119,10 @@ Line 3 has `InvalidClass3`
 def test_check_qmd_file_with_exclude_pattern(tmp_path):
     """Test that exclude pattern works."""
     qmd_file = tmp_path / "test.qmd"
-    qmd_file.write_text(
-        """
+    qmd_file.write_text("""
 This has `firecrown.example.ExampleClass` which should be excluded.
 This has `firecrown.real.RealClass` which should be checked.
-"""
-    )
+""")
 
     symbol_map = {
         "firecrown.real.RealClass": "api/...",
@@ -152,11 +141,9 @@ This has `firecrown.real.RealClass` which should be checked.
 def test_check_qmd_file_lowercase_code_not_checked(tmp_path):
     """Test that lowercase code spans are not checked as symbols."""
     qmd_file = tmp_path / "test.qmd"
-    qmd_file.write_text(
-        """
+    qmd_file.write_text("""
 This has `some_function` and `another_var` which are lowercase.
-"""
-    )
+""")
 
     symbol_map: dict[str, str] = {}  # Empty symbol map
 
@@ -168,11 +155,9 @@ This has `some_function` and `another_var` which are lowercase.
 def test_check_qmd_file_partial_module_path(tmp_path):
     """Test validation of partial module paths."""
     qmd_file = tmp_path / "test.qmd"
-    qmd_file.write_text(
-        """
+    qmd_file.write_text("""
 Reference to `firecrown.likelihood` module.
-"""
-    )
+""")
 
     symbol_map = {
         "firecrown.likelihood": "api/...",

--- a/tests/fctools/test_tracer.py
+++ b/tests/fctools/test_tracer.py
@@ -448,14 +448,12 @@ def test_main_traces_script(tmp_path):
     """Test main traces a Python script."""
     # Create a simple test script
     script_file = tmp_path / "test_script.py"
-    script_file.write_text(
-        """
+    script_file.write_text("""
 def simple_function():
     return 42
 
 result = simple_function()
-"""
-    )
+""")
 
     trace_file = tmp_path / "output.tsv"
 
@@ -835,14 +833,12 @@ def test_tracing_with_nested_calls(tmp_path):
 def test_cli_produces_valid_tsv(tmp_path):
     """Test that CLI produces valid TSV file."""
     script_file = tmp_path / "test_script.py"
-    script_file.write_text(
-        """
+    script_file.write_text("""
 def func():
     return 1
 
 func()
-"""
-    )
+""")
     trace_file = tmp_path / "output.tsv"
 
     result = subprocess.run(

--- a/tests/likelihood/gauss_family/statistic/test_statistic.py
+++ b/tests/likelihood/gauss_family/statistic/test_statistic.py
@@ -12,7 +12,6 @@ import firecrown.likelihood._statistic as stat
 from firecrown.modeling_tools import ModelingTools
 from firecrown.updatable import ParamsMap
 
-
 VECTOR_CLASSES = (firecrown.data_types.TheoryVector, firecrown.data_types.DataVector)
 
 

--- a/tests/likelihood/gauss_family/statistic/test_two_point.py
+++ b/tests/likelihood/gauss_family/statistic/test_two_point.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 import pyccl
+import sacc
 from hypothesis import given, assume
 from hypothesis.strategies import floats, integers
 
@@ -861,3 +862,133 @@ def test_calculate_pk_with_halo_model():
 
         # Verify that tools.has_pk was called (ensuring we didn't take the first branch)
         tools.has_pk.assert_called_once_with("test_pk")
+
+
+def test_two_point_normalize_window_default():
+    """Test that TwoPoint.normalize_window defaults to True."""
+    source = NumberCounts(sacc_tracer="lens_0")
+    two_point = tp.TwoPoint(
+        sacc_data_type="galaxy_density_cl",
+        source0=source,
+        source1=source,
+    )
+    assert two_point.normalize_window is True
+
+
+def test_two_point_normalize_window_false():
+    """Test that TwoPoint.normalize_window can be set to False."""
+    source = NumberCounts(sacc_tracer="lens_0")
+    two_point = tp.TwoPoint(
+        sacc_data_type="galaxy_density_cl",
+        source0=source,
+        source1=source,
+        normalize_window=False,
+    )
+    assert two_point.normalize_window is False
+
+
+def test_two_point_normalize_window_true_explicit():
+    """Test that TwoPoint.normalize_window can be explicitly set to True."""
+    source = NumberCounts(sacc_tracer="lens_0")
+    two_point = tp.TwoPoint(
+        sacc_data_type="galaxy_density_cl",
+        source0=source,
+        source1=source,
+        normalize_window=True,
+    )
+    assert two_point.normalize_window is True
+
+
+@pytest.fixture(name="sacc_with_window_for_two_point")
+def fixture_sacc_with_window_for_two_point(tmp_path):
+    """Create a SACC file with window functions for TwoPoint testing."""
+    import pyccl
+
+    # Create window function data
+    n_ell_bin = 5
+    ell_bin_edges = np.geomspace(10, 500, n_ell_bin + 1)
+    ell_bin_centers = np.sqrt(ell_bin_edges[:-1] * ell_bin_edges[1:])
+    ell_bin_widths = np.diff(ell_bin_edges)
+
+    ell_window = np.arange(800)
+    window_function = np.zeros((ell_window.shape[0], n_ell_bin))
+    for i, (mu_ell, sigma_ell) in enumerate(zip(ell_bin_centers, ell_bin_widths)):
+        window_function[:, i] = np.exp(
+            -0.5 * (ell_window - mu_ell) ** 2 / (sigma_ell) ** 2
+        )
+
+    # Intentionally NOT normalizing the window so we can test the difference
+
+    # Create SACC data
+    sacc_data = sacc.Sacc()
+    z = np.linspace(0, 2.0, 50)
+
+    # Add src0 tracer for WeakLensing
+    dndz = np.exp(-0.5 * (z - 0.5) ** 2 / 0.1**2)
+    sacc_data.add_tracer("NZ", "src0", z, dndz)
+
+    # Create cosmology for realistic data
+    cosmo = pyccl.CosmologyVanillaLCDM()
+    tracer = sacc_data.get_tracer("src0")
+    ccl_tracer = pyccl.WeakLensingTracer(cosmo=cosmo, dndz=(tracer.z, tracer.nz))
+
+    # Add data with window function
+    window = sacc.BandpowerWindow(ell_window, window_function)
+    Cell = pyccl.angular_cl(
+        cosmo=cosmo, tracer1=ccl_tracer, tracer2=ccl_tracer, ell=ell_window
+    )
+    Cell_binned = window_function.T @ Cell
+    sacc_data.add_ell_cl(
+        data_type="galaxy_shear_cl_ee",
+        tracer1="src0",
+        tracer2="src0",
+        ell=ell_bin_centers,
+        x=Cell_binned,
+        window=window,
+    )
+
+    # Add covariance
+    sacc_data.add_covariance(np.identity(len(sacc_data)) * 0.01)
+
+    return sacc_data
+
+
+def test_two_point_normalize_window_used_in_read(sacc_with_window_for_two_point):
+    """Test that normalize_window is actually used during read."""
+    # Use SACC data with window functions from fixture
+    sacc_data = sacc_with_window_for_two_point
+
+    # Create two TwoPoint objects: one with normalize_window=True, one False
+    source = WeakLensing(sacc_tracer="src0")
+
+    two_point_normalized = tp.TwoPoint(
+        sacc_data_type="galaxy_shear_cl_ee",
+        source0=source,
+        source1=source,
+        normalize_window=True,
+    )
+
+    two_point_unnormalized = tp.TwoPoint(
+        sacc_data_type="galaxy_shear_cl_ee",
+        source0=source,
+        source1=source,
+        normalize_window=False,
+    )
+
+    # Read data
+    two_point_normalized.read(sacc_data)
+    two_point_unnormalized.read(sacc_data)
+
+    # If window functions were present, they should be different
+    # (unless unnormalized already sums to 1)
+    if two_point_normalized.theory.window is not None:
+        assert two_point_unnormalized.theory.window is not None
+
+        # Normalized should sum to 1
+        assert np.allclose(two_point_normalized.theory.window.sum(axis=0), 1.0)
+
+        # Check if they differ (they should unless unnormalized already sums to 1)
+        if not np.allclose(two_point_unnormalized.theory.window.sum(axis=0), 1.0):
+            assert not np.allclose(
+                two_point_normalized.theory.window, two_point_unnormalized.theory.window
+            )

--- a/tests/likelihood/lkdir/lkscript_old.py
+++ b/tests/likelihood/lkdir/lkscript_old.py
@@ -4,6 +4,5 @@ Provides a trivial likelihood factory function for testing purposes.
 
 from . import lkmodule
 
-
 # Defines a module variable "likelihood"
 likelihood = lkmodule.empty_likelihood()

--- a/tests/likelihood/test_factories.py
+++ b/tests/likelihood/test_factories.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 import numpy as np
 
+import pyccl
 import sacc
 from firecrown.metadata_types import TwoPointCorrelationSpace
 from firecrown.likelihood.factories import (
@@ -32,7 +33,11 @@ from firecrown.metadata_types import (
     CMB_TYPES,
 )
 from firecrown.data_types import TwoPointMeasurement
-from firecrown.data_functions import TwoPointBinFilterCollection, TwoPointBinFilter
+from firecrown.data_functions import (
+    TwoPointBinFilterCollection,
+    TwoPointBinFilter,
+    extract_all_harmonic_data,
+)
 from firecrown.utils import (
     base_model_from_yaml,
     base_model_to_yaml,
@@ -1189,3 +1194,222 @@ def test_load_sacc_data_with_string():
     sacc_data = load_sacc_data("tests/bug_398.sacc.gz")
     assert sacc_data is not None
     assert isinstance(sacc_data, sacc.Sacc)
+
+
+@pytest.fixture(name="sacc_with_window", scope="function")
+def fixture_sacc_with_window(tmp_path: Path):
+    """Create a SACC file with window functions for testing normalize_window."""
+    # Create window function data
+    n_ell_bin = 5
+    ell_bin_edges = np.geomspace(10, 500, n_ell_bin + 1)
+    ell_bin_centers = np.sqrt(ell_bin_edges[:-1] * ell_bin_edges[1:])
+    ell_bin_widths = np.diff(ell_bin_edges)
+
+    ell_window = np.arange(800)
+    window_function = np.zeros((ell_window.shape[0], n_ell_bin))
+    for i, (mu_ell, sigma_ell) in enumerate(zip(ell_bin_centers, ell_bin_widths)):
+        window_function[:, i] = np.exp(
+            -0.5 * (ell_window - mu_ell) ** 2 / (sigma_ell) ** 2
+        )
+
+    # Intentionally NOT normalizing - so we can test the difference
+    # window_function = window_function / window_function.sum(axis=0, keepdims=True)
+
+    # Create SACC data
+    sacc_data = sacc.Sacc()
+    z = np.linspace(0, 2.0, 50)
+
+    # Add tracers
+    for i in range(2):
+        dndz = np.exp(-0.5 * (z - 0.5 * (i + 1)) ** 2 / 0.1**2)
+        sacc_data.add_tracer("NZ", f"src{i}", z, dndz)
+
+    # Create cosmology for realistic data
+    cosmo = pyccl.CosmologyVanillaLCDM()
+    ccl_tracers = {}
+    for i in range(2):
+        tracer = sacc_data.get_tracer(f"src{i}")
+        ccl_tracers[f"src{i}"] = pyccl.WeakLensingTracer(
+            cosmo=cosmo, dndz=(tracer.z, tracer.nz)
+        )
+
+    # Add data with window functions
+    window = sacc.BandpowerWindow(ell_window, window_function)
+    for i in range(2):
+        for j in range(i, 2):
+            Cell = pyccl.angular_cl(
+                cosmo=cosmo,
+                tracer1=ccl_tracers[f"src{i}"],
+                tracer2=ccl_tracers[f"src{j}"],
+                ell=ell_window,
+            )
+            Cell_binned = window_function.T @ Cell
+            sacc_data.add_ell_cl(
+                data_type="galaxy_shear_cl_ee",
+                tracer1=f"src{i}",
+                tracer2=f"src{j}",
+                ell=ell_bin_centers,
+                x=Cell_binned,
+                window=window,
+            )
+
+    # Add covariance
+    sacc_data.add_covariance(np.identity(len(sacc_data)) * 0.01)
+
+    # Save to file
+    sacc_file = tmp_path / "test_window.fits"
+    sacc_data.save_fits(str(sacc_file), overwrite=True)
+
+    return sacc_file
+
+
+def test_data_source_sacc_normalize_window_default(sacc_with_window: Path):
+    """Test that DataSourceSacc.normalize_window defaults to True."""
+    data_source = DataSourceSacc(sacc_data_file=str(sacc_with_window))
+    assert data_source.normalize_window is True
+
+
+def test_data_source_sacc_normalize_window_false_dict(sacc_with_window: Path):
+    """Test DataSourceSacc.normalize_window can be set to False via dict."""
+    data_source_dict = {
+        "sacc_data_file": str(sacc_with_window),
+        "normalize_window": False,
+    }
+    data_source = DataSourceSacc.model_validate(data_source_dict)
+    assert data_source.normalize_window is False
+
+
+def test_data_source_sacc_normalize_window_false_direct(sacc_with_window: Path):
+    """Test DataSourceSacc.normalize_window can be set to False directly."""
+    data_source = DataSourceSacc(
+        sacc_data_file=str(sacc_with_window), normalize_window=False
+    )
+    assert data_source.normalize_window is False
+
+
+def test_data_source_sacc_normalize_window_true_explicit(sacc_with_window: Path):
+    """Test DataSourceSacc.normalize_window can be explicitly set to True."""
+    data_source = DataSourceSacc(
+        sacc_data_file=str(sacc_with_window), normalize_window=True
+    )
+    assert data_source.normalize_window is True
+
+
+def test_two_point_experiment_normalize_window_flows_through(
+    empty_factory_harmonic: TwoPointFactory,
+    sacc_with_window: Path,
+):
+    """Test that normalize_window flows through TwoPointExperiment to likelihood."""
+    # Create experiment with normalize_window=False
+    experiment = TwoPointExperiment(
+        two_point_factory=empty_factory_harmonic,
+        data_source=DataSourceSacc(
+            sacc_data_file=str(sacc_with_window), normalize_window=False
+        ),
+    )
+
+    # Verify the attribute is set correctly
+    assert experiment.data_source.normalize_window is False
+
+    # Make likelihood - this should not raise an error
+    likelihood = experiment.make_likelihood()
+    assert likelihood is not None
+
+
+def test_two_point_experiment_normalize_window_default_flows_through(
+    empty_factory_harmonic: TwoPointFactory,
+    sacc_with_window: Path,
+):
+    """Test that default normalize_window=True flows through correctly."""
+    experiment = TwoPointExperiment(
+        two_point_factory=empty_factory_harmonic,
+        data_source=DataSourceSacc(sacc_data_file=str(sacc_with_window)),
+    )
+
+    # Verify the default is True
+    assert experiment.data_source.normalize_window is True
+
+    # Make likelihood - this should not raise an error
+    likelihood = experiment.make_likelihood()
+    assert likelihood is not None
+
+
+def test_normalize_window_affects_extraction(sacc_with_window: Path):
+    """Test that normalize_window parameter actually affects window extraction."""
+    sacc_data = load_sacc_data(sacc_with_window)
+
+    # Extract with normalization (default)
+    data_normalized = extract_all_harmonic_data(sacc_data, normalize=True)
+
+    # Extract without normalization
+    data_unnormalized = extract_all_harmonic_data(sacc_data, normalize=False)
+
+    # Both should have the same number of measurements
+    assert len(data_normalized) == len(data_unnormalized)
+
+    # Check if any measurements have window functions
+    has_window = False
+    for measurement_norm, measurement_unnorm in zip(data_normalized, data_unnormalized):
+        assert isinstance(measurement_norm.metadata, TwoPointHarmonic)
+        assert isinstance(measurement_unnorm.metadata, TwoPointHarmonic)
+        if measurement_norm.metadata.window is not None:
+            has_window = True
+            window_norm = measurement_norm.metadata.window
+            window_unnorm = measurement_unnorm.metadata.window
+
+            # Windows should exist in both
+            assert window_unnorm is not None
+
+            # Normalized window should sum to 1 along axis 0
+            assert np.allclose(window_norm.sum(axis=0), 1.0)
+
+            # Unnormalized window should NOT necessarily sum to 1
+            # (unless it happens to by coincidence)
+            # But we can verify that normalized != unnormalized (when they differ)
+            if not np.allclose(window_unnorm.sum(axis=0), 1.0):
+                # If unnormalized doesn't sum to 1, they should be different
+                assert not np.allclose(window_norm, window_unnorm)
+
+                # The normalized should be the unnormalized divided by its sum
+                expected_normalized = window_unnorm / window_unnorm.sum(axis=0)
+                assert np.allclose(window_norm, expected_normalized)
+
+    # Verify we actually tested something with windows
+    assert has_window, "No window functions found in test data"
+
+
+def test_two_point_experiment_yaml_with_normalize_window(
+    tmp_path: Path, sacc_with_window: Path
+):
+    """Test TwoPointExperiment loading from YAML with normalize_window=False."""
+    tmp_experiment_file = tmp_path / "experiment_no_norm.yaml"
+    # Use relative path from tmp_path to sacc_with_window
+    sacc_path_relative_to_tmp_path = relative_to_with_walk_up(
+        tmp_path, sacc_with_window
+    )
+
+    tmp_experiment_file.write_text(f"""
+two_point_factory:
+  correlation_space: harmonic
+  weak_lensing_factories:
+    - type_source: default
+      per_bin_systematics: []
+      global_systematics: []
+  number_counts_factories:
+    - type_source: default
+      per_bin_systematics: []
+      global_systematics: []
+data_source:
+  sacc_data_file: {sacc_path_relative_to_tmp_path}
+  normalize_window: false
+""")
+
+    # Load the experiment
+    experiment = TwoPointExperiment.load_from_yaml(tmp_experiment_file)
+
+    # Verify normalize_window is set to False
+    assert experiment.data_source.normalize_window is False
+
+    # Create likelihood to ensure it works end-to-end
+    likelihood = experiment.make_likelihood()
+    assert likelihood is not None

--- a/tests/likelihood/test_factories.py
+++ b/tests/likelihood/test_factories.py
@@ -411,8 +411,7 @@ def test_build_two_point_likelihood_real(
         tmp_path, absolute_sacc_path
     )
 
-    tmp_experiment_file.write_text(
-        f"""
+    tmp_experiment_file.write_text(f"""
 two_point_factory:
   correlation_space: real
   weak_lensing_factories:
@@ -428,8 +427,7 @@ two_point_factory:
     limber_method: gsl_spline
 data_source:
     sacc_data_file: {sacc_path_relative_to_tmp_path}
-"""
-    )
+""")
 
     build_parameters = NamedParameters({"likelihood_config": str(tmp_experiment_file)})
     likelihood, tools = build_two_point_likelihood(build_parameters)
@@ -447,8 +445,7 @@ def test_build_two_point_likelihood_harmonic(
         tmp_path, absolute_sacc_path
     )
 
-    tmp_experiment_file.write_text(
-        f"""
+    tmp_experiment_file.write_text(f"""
 two_point_factory:
   correlation_space: harmonic
   weak_lensing_factories:
@@ -464,8 +461,7 @@ two_point_factory:
     limber_method: gsl_spline
 data_source:
     sacc_data_file: {sacc_path_relative_to_tmp_path}
-"""
-    )
+""")
 
     build_parameters = NamedParameters({"likelihood_config": str(tmp_experiment_file)})
     likelihood, tools = build_two_point_likelihood(build_parameters)
@@ -483,8 +479,7 @@ def test_build_two_point_likelihood_real_no_real_data(
         tmp_path, absolute_sacc_path
     )
 
-    tmp_experiment_file.write_text(
-        f"""
+    tmp_experiment_file.write_text(f"""
 two_point_factory:
   correlation_space: real
   weak_lensing_factories:
@@ -500,8 +495,7 @@ two_point_factory:
     limber_method: gsl_spline
 data_source:
     sacc_data_file: {sacc_path_relative_to_tmp_path}
-"""
-    )
+""")
 
     build_parameters = NamedParameters({"likelihood_config": str(tmp_experiment_file)})
     with pytest.raises(
@@ -523,8 +517,7 @@ def test_build_two_point_likelihood_harmonic_no_harmonic_data(
         tmp_path, absolute_sacc_path
     )
 
-    tmp_experiment_file.write_text(
-        f"""
+    tmp_experiment_file.write_text(f"""
 two_point_factory:
   correlation_space: harmonic
   weak_lensing_factories:
@@ -540,8 +533,7 @@ two_point_factory:
     limber_method: gsl_spline
 data_source:
   sacc_data_file: {sacc_path_relative_to_tmp_path}
-"""
-    )
+""")
 
     build_parameters = NamedParameters({"likelihood_config": str(tmp_experiment_file)})
     with pytest.raises(

--- a/tests/metadata/sacc_name_mapping.py
+++ b/tests/metadata/sacc_name_mapping.py
@@ -6,7 +6,6 @@ from firecrown.metadata_types import (
     Galaxies,
 )
 
-
 mappings = [
     (
         "clusterGalaxy_densityShear_cl_e",

--- a/tests/metadata/test_metadata_two_point_sacc.py
+++ b/tests/metadata/test_metadata_two_point_sacc.py
@@ -677,7 +677,7 @@ def test_extract_all_harmonic_metadata_normalize_true(sacc_galaxy_cwindows):
 
 
 def test_extract_all_harmonic_metadata_normalize_false(sacc_galaxy_cwindows):
-    """Test that normalize=False keeps windows unnormalized in extract_all_harmonic_metadata."""
+    """Test that normalize=False keeps windows unnormalized."""
     sacc_data, _, _ = sacc_galaxy_cwindows
 
     two_point_harmonics = extract_all_harmonic_metadata(sacc_data, normalize=False)

--- a/tests/metadata/test_metadata_two_point_sacc.py
+++ b/tests/metadata/test_metadata_two_point_sacc.py
@@ -7,7 +7,7 @@ import warnings
 import re
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 
 
 import sacc
@@ -659,6 +659,55 @@ def test_constructor_harmonic_with_window_metadata(sacc_galaxy_cwindows, tp_fact
             window.weight / window.weight.sum(axis=0),
         )
         assert_array_equal(two_point.ells, window.values)
+
+
+def test_extract_all_harmonic_metadata_normalize_true(sacc_galaxy_cwindows):
+    """Test that normalize=True normalizes windows in extract_all_harmonic_metadata."""
+    sacc_data, _, _ = sacc_galaxy_cwindows
+
+    two_point_harmonics = extract_all_harmonic_metadata(sacc_data, normalize=True)
+
+    assert len(two_point_harmonics) > 0
+
+    for metadata in two_point_harmonics:
+        assert metadata.window is not None
+        # Normalized windows should sum to 1 along axis 0
+        window_sum = metadata.window.sum(axis=0)
+        assert_allclose(window_sum, np.ones_like(window_sum))
+
+
+def test_extract_all_harmonic_metadata_normalize_false(sacc_galaxy_cwindows):
+    """Test that normalize=False keeps windows unnormalized in extract_all_harmonic_metadata."""
+    sacc_data, _, _ = sacc_galaxy_cwindows
+
+    two_point_harmonics = extract_all_harmonic_metadata(sacc_data, normalize=False)
+
+    assert len(two_point_harmonics) > 0
+
+    for metadata in two_point_harmonics:
+        assert metadata.window is not None
+        # Unnormalized windows should NOT sum to 1 along axis 0
+        # The fixture creates weights with multiple identity matrices,
+        # so the sum should be greater than 1
+        window_sum = metadata.window.sum(axis=0)
+        # Check that at least some values are not close to 1.0
+        # (i.e., windows are not normalized)
+        assert not np.allclose(window_sum, np.ones_like(window_sum))
+
+
+def test_extract_all_harmonic_metadata_default_normalizes(sacc_galaxy_cwindows):
+    """Test that the default behavior (no normalize parameter) normalizes windows."""
+    sacc_data, _, _ = sacc_galaxy_cwindows
+
+    two_point_harmonics = extract_all_harmonic_metadata(sacc_data)
+
+    assert len(two_point_harmonics) > 0
+
+    for metadata in two_point_harmonics:
+        assert metadata.window is not None
+        # Default should normalize windows (sum to 1 along axis 0)
+        window_sum = metadata.window.sum(axis=0)
+        assert_allclose(window_sum, np.ones_like(window_sum))
 
 
 @pytest.mark.slow

--- a/tests/metadata/test_metadata_two_point_sacc.py
+++ b/tests/metadata/test_metadata_two_point_sacc.py
@@ -710,6 +710,137 @@ def test_extract_all_harmonic_metadata_default_normalizes(sacc_galaxy_cwindows):
         assert_allclose(window_sum, np.ones_like(window_sum))
 
 
+def test_extract_window_function_raises_on_zero_weight():
+    """Test that extract_window_function raises ValueError for zero-weight columns."""
+    sacc_data = sacc.Sacc()
+
+    z = np.linspace(0, 1.0, 50)
+    ells = np.array([10, 20, 30, 40, 50], dtype=np.int64)
+
+    # Add a tracer
+    dndz = np.exp(-0.5 * (z - 0.5) ** 2 / 0.1 / 0.1)
+    sacc_data.add_tracer("NZ", "src0", z, dndz)
+
+    # Create weights with a zero column (column index 1)
+    weights = np.array(
+        [
+            [1.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    window = sacc.BandpowerWindow(ells, weights)
+    Cells = np.array([100.0, 0.0, 150.0])
+
+    sacc_data.add_ell_cl(
+        "galaxy_shear_cl_ee",
+        "src0",
+        "src0",
+        weights.T.dot(ells),
+        Cells,
+        window=window,
+    )
+
+    # Get indices for the data we just added
+    _, _, indices = sacc_data.get_ell_cl(
+        "galaxy_shear_cl_ee", "src0", "src0", return_ind=True, return_cov=False
+    )
+
+    # Should raise ValueError mentioning column index 1
+    with pytest.raises(
+        ValueError, match=r"Window function has zero total weight.*\[1\]"
+    ):
+        extract_window_function(sacc_data, indices, normalize=True)
+
+
+def test_extract_window_function_raises_on_multiple_zero_weights():
+    """Test that extract_window_function reports multiple zero-weight columns."""
+    sacc_data = sacc.Sacc()
+
+    z = np.linspace(0, 1.0, 50)
+    ells = np.array([10, 20, 30, 40, 50], dtype=np.int64)
+
+    # Add a tracer
+    dndz = np.exp(-0.5 * (z - 0.5) ** 2 / 0.1 / 0.1)
+    sacc_data.add_tracer("NZ", "src0", z, dndz)
+
+    # Create weights with multiple zero columns (columns 0 and 2)
+    weights = np.array(
+        [
+            [0.0, 1.0, 0.0],
+            [0.0, 0.5, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.5, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    window = sacc.BandpowerWindow(ells, weights)
+    Cells = np.array([0.0, 100.0, 0.0])
+
+    sacc_data.add_ell_cl(
+        "galaxy_shear_cl_ee",
+        "src0",
+        "src0",
+        weights.T.dot(ells),
+        Cells,
+        window=window,
+    )
+
+    # Get indices
+    _, _, indices = sacc_data.get_ell_cl(
+        "galaxy_shear_cl_ee", "src0", "src0", return_ind=True, return_cov=False
+    )
+
+    # Should raise ValueError mentioning both column indices
+    with pytest.raises(
+        ValueError, match=r"Window function has zero total weight.*\[0, 2\]"
+    ):
+        extract_window_function(sacc_data, indices, normalize=False)
+
+
+def test_extract_all_harmonic_metadata_raises_on_zero_weight():
+    """Test that extract_all_harmonic_metadata raises ValueError for zero weights."""
+    sacc_data = sacc.Sacc()
+
+    z = np.linspace(0, 1.0, 50)
+    ells = np.array([10, 20, 30, 40, 50], dtype=np.int64)
+
+    # Add tracers
+    dndz = np.exp(-0.5 * (z - 0.5) ** 2 / 0.1 / 0.1)
+    sacc_data.add_tracer("NZ", "src0", z, dndz)
+
+    # Create weights with a zero column
+    weights = np.array(
+        [
+            [1.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    window = sacc.BandpowerWindow(ells, weights)
+    Cells = np.array([100.0, 0.0, 150.0])
+
+    sacc_data.add_ell_cl(
+        "galaxy_shear_cl_ee",
+        "src0",
+        "src0",
+        weights.T.dot(ells),
+        Cells,
+        window=window,
+    )
+
+    # Should raise ValueError when trying to extract metadata
+    with pytest.raises(ValueError, match="Window function has zero total weight"):
+        extract_all_harmonic_metadata(sacc_data, normalize=True)
+
+
 @pytest.mark.slow
 def test_constructor_harmonic_with_window_data(sacc_galaxy_cwindows, tp_factory):
     sacc_data, _, tracer_pairs = sacc_galaxy_cwindows

--- a/tests/models/cluster/test_integrators.py
+++ b/tests/models/cluster/test_integrators.py
@@ -6,7 +6,6 @@ import pytest
 from firecrown.models.cluster import ScipyIntegrator
 from firecrown.models.cluster import NumCosmoIntegrator
 
-
 # @pytest.fixture(name="integrator", params=[ScipyIntegrator, NumCosmoIntegrator])
 # def fixture_integrator(request) -> Integrator:
 #     return request.param()

--- a/tests/models/cluster/test_mass_proxy.py
+++ b/tests/models/cluster/test_mass_proxy.py
@@ -11,7 +11,6 @@ from firecrown.models.cluster import (
     MassRichnessGaussian,
 )
 
-
 PIVOT_Z = 0.6
 PIVOT_MASS = 14.625862906
 

--- a/tests/test_pyccl.py
+++ b/tests/test_pyccl.py
@@ -6,7 +6,6 @@ future release of pyccl.
 import pytest
 import pyccl
 
-
 # Both sets of cosmological parameters are silly, but they are sufficient to initialize
 # a pyccl.Cosmology object.
 


### PR DESCRIPTION
## Description

Window functions extracted from SACC files are automatically normalized (weights divided by their sum) during extraction. However, this normalization is not always appropriate for all use cases. Users need the ability to disable this automatic normalization when it produces incorrect results for their analysis.

Fixes #624 

## Type of change

* New feature (non-breaking change which adds functionality)
* Refactoring

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
