### PR TITLE
Fix the call to MuSigmaMG.

### DIFF
--- a/firecrown/ccl_factory.py
+++ b/firecrown/ccl_factory.py
@@ -179,7 +179,13 @@ class MuSigmaModel(Updatable):
         if not self.is_updated():
             raise ValueError("Parameters have not been updated yet.")
 
-        return MuSigmaMG(self.mu, self.sigma, self.c1, self.c2, self.lambda0)
+        return MuSigmaMG(
+            mu_0=self.mu,
+            sigma_0=self.sigma,
+            c1_mg=self.c1,
+            c2_mg=self.c2,
+            lambda_mg=self.lambda0,
+        )
 
 
 class CAMBExtraParams(BaseModel):

--- a/firecrown/ccl_factory.py
+++ b/firecrown/ccl_factory.py
@@ -167,12 +167,12 @@ class MuSigmaModel(Updatable):
         """Initialize the MuSigmaModel object."""
         super().__init__(parameter_prefix="mg_musigma")
 
-        self.mu = register_new_updatable_parameter(default_value=1.0)
-        self.sigma = register_new_updatable_parameter(default_value=1.0)
+        self.mu = register_new_updatable_parameter(default_value=0.0)
+        self.sigma = register_new_updatable_parameter(default_value=0.0)
         self.c1 = register_new_updatable_parameter(default_value=1.0)
         self.c2 = register_new_updatable_parameter(default_value=1.0)
         # We cannot clash with the lambda keyword
-        self.lambda0 = register_new_updatable_parameter(default_value=1.0)
+        self.lambda0 = register_new_updatable_parameter(default_value=0.0)
 
     def create(self) -> MuSigmaMG:
         """Create a `pyccl.modified_gravity.MuSigmaMG` object."""

--- a/tests/test_ccl_factory.py
+++ b/tests/test_ccl_factory.py
@@ -934,12 +934,23 @@ def test_mu_sigma_model() -> None:
     assert mu_sigma_model is not None
 
     default_params = get_default_params_map(mu_sigma_model)
+    default_params["mg_musigma_mu"] = 1.0
+    default_params["mg_musigma_sigma"] = 2.0
+    default_params["mg_musigma_c1"] = 3.0
+    default_params["mg_musigma_c2"] = 4.0
+    default_params["mg_musigma_lambda0"] = 5.0
 
     mu_sigma_model.update(default_params)
 
     musigma = mu_sigma_model.create()
 
     assert musigma is not None
+    assert musigma.parametrization == "mu_Sigma"
+    assert musigma.mu_0 == 1.0
+    assert musigma.sigma_0 == 2.0
+    assert musigma.c1_mg == 3.0
+    assert musigma.c2_mg == 4.0
+    assert musigma.lambda_mg == 5.0
     assert isinstance(musigma, pyccl.modified_gravity.MuSigmaMG)
 
 


### PR DESCRIPTION
## Description

Fix the call to MuSigmaMG to use keyword arguments to avoid wrong positioning.

Fixes #637 

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

- [x] I have run `bash pre-commit-check` and fixed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
