### PR TITLE
Fix conda-forge release procedure (#647)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SHELL := /bin/bash
 	test-models-cluster test-models-two-point unit-tests test-ci test-all-coverage \
 	unit-tests-pre unit-tests-post unit-tests-core docs-generate-symbol-map \
 	release-env-check release-build-check release-gh-check conda-lock conda-lock-check \
-	release-validate release-check release-tag release-sdist release-verify-sdist release-push \
+	release-validate release-check release-tag release-sdist release-verify-sdist release-verify-archive release-push \
 	release-github release-clean \
 	release-conda-forge \
 	docs-verify docs-code-check docs-symbol-check docs-linkcheck
@@ -536,6 +536,37 @@ release-verify-sdist: release-sdist ## Verify the release sdist VERSION=x.y.z
 	PYTHONPATH="$$target_dir" $(PYTHON) -c "import importlib.metadata; import firecrown; expected='$(VERSION)'; assert importlib.metadata.version('firecrown') == expected, importlib.metadata.version('firecrown'); assert firecrown.__version__ == expected, firecrown.__version__"
 	echo "✅ Verified $(RELEASE_SDIST)"
 
+release-verify-archive: ## Confirm the GitHub auto-archive is NOT a valid conda-forge source VERSION=x.y.z
+	@if [[ -z "$(VERSION)" ]]; then
+		echo "VERSION is required. Use: make $@ VERSION=x.y.z"
+		exit 1
+	fi
+	if ! git rev-parse -q --verify "refs/tags/v$(VERSION)" >/dev/null; then
+		echo "Local tag v$(VERSION) was not found. Run: make release-tag VERSION=$(VERSION)"
+		exit 1
+	fi
+	tmpdir="$$(mktemp -d)"
+	trap 'rm -rf "$$tmpdir"' EXIT
+	archive_dir="$$tmpdir/archive"
+	mkdir -p "$$archive_dir"
+	git archive "v$(VERSION)" | tar -x -C "$$archive_dir"
+	target_dir="$$tmpdir/site"
+	mkdir -p "$$target_dir"
+	echo "Installing from auto-archive tree (no .git, no PKG-INFO)..."
+	if $(PYTHON) -m pip install --no-deps --no-build-isolation --target "$$target_dir" "$$archive_dir" >/dev/null 2>&1; then
+		installed_version="$$(cd "$$tmpdir" && PYTHONPATH="$$target_dir" $(PYTHON) -c "import importlib.metadata; print(importlib.metadata.version('firecrown'))" 2>/dev/null || echo unknown)"
+		if [[ "$$installed_version" == "$(VERSION)" ]]; then
+			echo "❌ Auto-archive unexpectedly produced the correct version ($$installed_version)."
+			echo "   The assumption that the auto-archive is unsupported is no longer valid."
+			echo "   Re-evaluate whether setuptools-scm can now read version from the archive."
+			exit 1
+		else
+			echo "✅ Auto-archive produced version '$$installed_version' (not '$(VERSION)') — unsupported source confirmed."
+		fi
+	else
+		echo "✅ Auto-archive install failed (setuptools-scm could not determine version) — unsupported source confirmed."
+	fi
+
 release-push:  ## Push the verified tag, plus .0 support branch VERSION=x.y.z
 	@$(MAKE) release-verify-sdist VERSION=$(VERSION)
 	if [[ -z "$(VERSION)" ]]; then
@@ -608,14 +639,38 @@ release-clean:  ## Remove local release state. Use VERSION=x.y.z to also remove 
 	fi
 	echo "✅ Local release state cleaned"
 
-release-conda-forge: release-gh-check ## Create conda-forge handoff issue for VERSION=x.y.z
+release-conda-forge: release-gh-check ## Create conda-forge handoff issue for VERSION=x.y.z (requires verified sdist in dist/)
 	@if [[ -z "$(VERSION)" ]]; then
 		echo "VERSION is required. Use: make $@ VERSION=x.y.z"
 		exit 1
 	fi
+	if [[ ! -f "$(RELEASE_SDIST)" ]]; then
+		echo "Release sdist was not found: $(RELEASE_SDIST)"
+		echo "Run: make release-verify-sdist VERSION=$(VERSION)"
+		exit 1
+	fi
+	sdist_sha256="$$(shasum -a 256 "$(RELEASE_SDIST)" | awk '{print $$1}')"
+	sdist_url="https://github.com/$(GITHUB_RELEASE_REPO)/releases/download/v$(VERSION)/firecrown-$(VERSION).tar.gz"
+	issue_body="$$(printf '%s\n' \
+		'Please update firecrown to v$(VERSION).' \
+		'' \
+		'**IMPORTANT**: The `source.url` in the recipe **must** point at the release sdist asset, NOT the GitHub auto-generated archive. The auto-archive (`/archive/v$(VERSION).tar.gz`) has no `PKG-INFO` and no `.git`, so `setuptools-scm` cannot determine the version — the package installs with `firecrown.__version__ == '"'"'0.0.0'"'"'`.' \
+		'' \
+		'Use the following `source` block verbatim:' \
+		'' \
+		'```yaml' \
+		'source:' \
+		"  url: $${sdist_url}" \
+		"  sha256: $${sdist_sha256}" \
+		'```' \
+		'' \
+		'Also ensure:' \
+		'- `setuptools-scm` is listed under `requirements.host`' \
+		'- `test.commands` asserts `firecrown.__version__ == '"'"'{{ version }}'"'"'` so any version mismatch fails the build immediately' \
+	)"
 	$(GH) issue create --repo "$(CONDA_FORGE_FEEDSTOCK_REPO)" \
-		--title "@conda-forge-admin, please update version" \
-		--body "Please update firecrown to v$(VERSION)."
+		--title "Update firecrown to v$(VERSION)" \
+		--body "$${issue_body}"
 
 ##@ Advanced
 

--- a/Making_a_new_release.md
+++ b/Making_a_new_release.md
@@ -70,6 +70,16 @@ This target never changes remote refs.
 The `release-push` target reruns the sdist verification and then pushes the tag to `origin`.
 For `x.y.0` releases, it also pushes `vx_y_support`.
 
+The `release-verify-archive` target confirms that the GitHub auto-archive
+(`/archive/vX.Y.Z.tar.gz`) is **not** a valid source for the conda-forge recipe.
+It produces a `.git`-less tree from the tag using `git archive`, installs it
+with `--no-deps --no-build-isolation`, and verifies that the installed version is
+**not** `x.y.z` (because the auto-archive has no `PKG-INFO` and `setuptools-scm`
+cannot determine the version).
+Run `make release-verify-archive VERSION=x.y.z` after tagging to document this
+constraint explicitly; a correct outcome prints a confirmation that the
+auto-archive source is unsupported.
+
 ## Publish the GitHub release
 
 1. Run `make release-github VERSION=x.y.z`.
@@ -80,13 +90,85 @@ For `x.y.0` releases, it also pushes `vx_y_support`.
 
 ## Start the conda-forge handoff
 
+### Required: use the release sdist, not the GitHub auto-archive
+
+The conda-forge recipe `source.url` **must** point at the **release sdist asset**
+uploaded to the GitHub release, not the GitHub auto-generated archive.
+
+| URL pattern | Acceptable? |
+|---|---|
+| `.../releases/download/vX.Y.Z/firecrown-X.Y.Z.tar.gz` | **Yes** — contains `PKG-INFO` with the correct version |
+| `.../archive/vX.Y.Z.tar.gz` | **No** — no `PKG-INFO`, no `.git`, `setuptools-scm` cannot resolve the version → `firecrown.__version__ == '0.0.0'` |
+
+The `make release-conda-forge` target (below) computes the sdist sha256 and
+emits the exact ready-to-paste `source` block so the correct URL is used
+every time.
+
+### Sync the feedstock fork before each handoff (manual git — no `make` target)
+
+Contributions to the conda-forge feedstock go through your own fork of the feedstock repository, such as
+`<github-username>/firecrown-feedstock` via a PR to
+`conda-forge/firecrown-feedstock`.
+Never push branches directly to the conda-forge feedstock (conda-forge policy).
+There is no `make` target for fork lifecycle management; the steps below are
+intentionally manual.
+
+**One-time setup** (first time only):
+
+```sh
+# In your local firecrown-feedstock clone:
+git remote add upstream https://github.com/conda-forge/firecrown-feedstock.git
+```
+
+**Before each handoff** — bring the fork up to date with conda-forge `main`:
+
+```sh
+git fetch upstream
+git checkout main
+git merge --ff-only upstream/main
+git push origin main
+
+# Create the fix/update branch off the synced main
+git checkout -b update-firecrown-x.y.z
+```
+
+### Handoff steps
+
 1. Run `make release-conda-forge VERSION=x.y.z`.
-2. The target requires an authenticated `gh` session and fails with login instructions when authentication is missing.
-3. The target creates the issue in [conda-forge/firecrown-feedstock](https://github.com/conda-forge/firecrown-feedstock).
-4. Review the PR created by the bot.
-5. In `recipe/meta.yaml`, confirm that the `version`, release-asset `source.url`, and `sha256` match the new sdist.
-6. Update any dependency versions required for the release.
-7. Add the comment `@conda-forge-admin, please rerender` to the PR.
-8. Wait for GitHub Actions to finish, approve the PR, and merge it.
+   The target requires:
+   - An authenticated `gh` session; it fails with login instructions when missing.
+   - The verified sdist `dist/firecrown-X.Y.Z.tar.gz` to exist; it fails with
+     instructions to run `make release-verify-sdist VERSION=x.y.z` when missing.
+
+   The target computes the sha256 of the local sdist and files an issue in
+   [conda-forge/firecrown-feedstock](https://github.com/conda-forge/firecrown-feedstock)
+   with the exact `source.url` (release sdist) and `sha256` ready to paste into
+   the recipe, along with a note that the auto-archive URL is not acceptable.
+
+2. Sync the feedstock fork and create a branch (see above).
+
+3. In `recipe/meta.yaml` on the update branch:
+   - Set `source.url` to the release sdist URL from the issue body
+     (`.../releases/download/vX.Y.Z/firecrown-X.Y.Z.tar.gz`).
+   - Set `source.sha256` to the value from the issue body.
+   - Ensure `setuptools-scm` is listed under `requirements.host`.
+   - Ensure `test.commands` contains a version assertion:
+     ```yaml
+      commands:
+        - python -c "import firecrown, importlib.metadata as md; assert firecrown.__version__ == '{{ version }}'; assert md.version('firecrown') == '{{ version }}'"
+     ```
+   - Update any dependency versions required for the release.
+   - Bump `build.number` when re-publishing the same version (corrected build);
+     reset to `0` for a new version.
+
+4. Push the branch to your fork and open a PR to `conda-forge/firecrown-feedstock`.
+
+5. Add the comment `@conda-forge-admin, please rerender` to the PR.
+
+6. Wait for GitHub Actions to finish on all variants.
+   The `test.commands` assertion will fail immediately on any build that does not
+   produce the correct version.
+
+7. Approve and merge the PR after CI passes.
 
 The same conda-forge handoff applies to feature-line releases and maintenance releases.


### PR DESCRIPTION
## Description

Fix conda-forge release procedure

Add release-verify-archive target to confirm GitHub auto-archives are not valid conda-forge sources. The auto-archive lacks PKG-INFO and .git, causing setuptools-scm to fail version detection.

Enhance release-conda-forge to require a verified sdist and compute its sha256, then emit a detailed GitHub issue body with the exact source block to paste into the recipe. This prevents accidental use of the unsupported auto-archive URL.

Add comprehensive documentation explaining the distinction between the release sdist (correct) and GitHub auto-archive (incorrect), plus manual git workflow steps for syncing the conda-forge feedstock fork.

Fix instructions to avoid just-fixed errors

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Bug fix (non-breaking change which fixes an issue)

## Checklist

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

* [x] I have run `make pre-commit` and fixed any issues
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have made corresponding changes to the documentation
* [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
