### PR TITLE
Fix exported names

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - quarto
   - requests
   - rich
-  - sacc >= 2.1
+  - sacc >= 2.1, < 2.2
   - scipy >= 1.13
   - sphinx
   - sphinx-autoapi

--- a/firecrown/app/sacc/__init__.py
+++ b/firecrown/app/sacc/__init__.py
@@ -3,5 +3,6 @@
 from ._transform import Transform, SaccFormat
 from ._load import Load
 from ._view import View
+from ._utils import mean_std_tracer
 
-__all__ = ["Transform", "Load", "SaccFormat", "View"]
+__all__ = ["Transform", "Load", "SaccFormat", "View", "mean_std_tracer"]

--- a/firecrown/fctools/measurement_compatibility.py
+++ b/firecrown/fctools/measurement_compatibility.py
@@ -23,12 +23,10 @@ from rich.console import Console
 from firecrown.metadata_types import (
     ALL_MEASUREMENTS,
     Measurement,
-)
-from firecrown.metadata_types._compatibility import (
     measurement_is_compatible_harmonic,
     measurement_is_compatible_real,
-    _measurement_supports_harmonic,
-    _measurement_supports_real,
+    measurement_supports_harmonic,
+    measurement_supports_real,
 )
 
 
@@ -49,9 +47,9 @@ def discover_measurements_by_space() -> tuple[list[Measurement], list[Measuremen
     all_measurements = ALL_MEASUREMENTS
 
     # Categorize by space support
-    real_measurements = [m for m in all_measurements if _measurement_supports_real(m)]
+    real_measurements = [m for m in all_measurements if measurement_supports_real(m)]
     harmonic_measurements = [
-        m for m in all_measurements if _measurement_supports_harmonic(m)
+        m for m in all_measurements if measurement_supports_harmonic(m)
     ]
 
     return real_measurements, harmonic_measurements

--- a/firecrown/likelihood/__init__.py
+++ b/firecrown/likelihood/__init__.py
@@ -32,13 +32,21 @@ Subpackages:
 from firecrown.likelihood._base import (
     Likelihood,
     NamedParameters,
+    PhotoZShiftFactory,
+    PhotoZShiftandStretchFactory,
     Source,
+    SourceGalaxy,
     SourceGalaxyArgs,
+    SourceGalaxyPhotoZShift,
+    SourceGalaxyPhotoZShiftandStretch,
+    SourceGalaxySelectField,
     SourceGalaxySystematic,
     SourceSystematic,
     Statistic,
     Tracer,
     TrivialStatistic,
+    dndz_shift_and_stretch_active,
+    dndz_shift_and_stretch_passive,
 )
 from firecrown.likelihood._likelihood import (
     load_likelihood,
@@ -53,7 +61,15 @@ from firecrown.likelihood._gaussian_pointmass import ConstGaussianPM
 from firecrown.likelihood._updatable_wrapper import UpdatableClusterObjects
 
 # Two-point statistics
-from firecrown.likelihood._two_point import TwoPoint, TwoPointFactory
+from firecrown.likelihood._two_point import (
+    TwoPoint,
+    TwoPointFactory,
+    use_source_factory,
+    use_source_factory_metadata_index,
+)
+
+# CMB statistics
+from firecrown.likelihood._cmb import CMBConvergenceFactory
 
 # Cluster statistics
 from firecrown.likelihood._binned_cluster import BinnedCluster
@@ -95,6 +111,10 @@ __all__ = [
     # Two-point statistics
     "TwoPoint",
     "TwoPointFactory",
+    "use_source_factory",
+    "use_source_factory_metadata_index",
+    # CMB statistics
+    "CMBConvergenceFactory",
     # Cluster statistics
     "BinnedCluster",
     "BinnedClusterNumberCounts",
@@ -102,11 +122,19 @@ __all__ = [
     # Supernova statistics
     "Supernova",
     # Source infrastructure
+    "PhotoZShiftFactory",
+    "PhotoZShiftandStretchFactory",
     "Source",
+    "SourceGalaxy",
     "SourceGalaxyArgs",
+    "SourceGalaxyPhotoZShift",
+    "SourceGalaxyPhotoZShiftandStretch",
+    "SourceGalaxySelectField",
     "SourceGalaxySystematic",
     "Tracer",
     "SourceSystematic",
+    "dndz_shift_and_stretch_active",
+    "dndz_shift_and_stretch_passive",
     # Base statistic class
     "Statistic",
     "TrivialStatistic",

--- a/firecrown/likelihood/factories/__init__.py
+++ b/firecrown/likelihood/factories/__init__.py
@@ -17,7 +17,12 @@ SACC file is being used without the need for complex customization.
 from firecrown.likelihood.factories._sacc_utils import load_sacc_data
 from firecrown.likelihood.factories._models import DataSourceSacc, TwoPointExperiment
 from firecrown.likelihood.factories._builders import build_two_point_likelihood
-from firecrown.likelihood._two_point import TwoPointFactory
+from firecrown.likelihood._two_point import (
+    TwoPointFactory,
+    use_source_factory,
+    use_source_factory_metadata_index,
+)
+from firecrown.likelihood.number_counts import NumberCountsFactory
 
 __all__ = [
     # SACC utilities
@@ -29,4 +34,7 @@ __all__ = [
     "build_two_point_likelihood",
     # Two-point factory
     "TwoPointFactory",
+    "NumberCountsFactory",
+    "use_source_factory",
+    "use_source_factory_metadata_index",
 ]

--- a/firecrown/likelihood/number_counts/__init__.py
+++ b/firecrown/likelihood/number_counts/__init__.py
@@ -1,21 +1,39 @@
 """Number counts source and systematics."""
 
+from firecrown.likelihood.number_counts._args import NumberCountsArgs
 from firecrown.likelihood.number_counts._source import NumberCounts
 from firecrown.likelihood.number_counts._factories import (
+    ConstantMagnificationBiasSystematicFactory,
+    LinearBiasSystematicFactory,
+    MagnificationBiasSystematicFactory,
     NumberCountsFactory,
+    NumberCountsSystematicFactory,
+    PTNonLinearBiasSystematicFactory,
 )
 from firecrown.likelihood.number_counts._systematics import (
     ConstantMagnificationBiasSystematic,
+    LinearBiasSystematic,
     MagnificationBiasSystematic,
+    NumberCountsSystematic,
     PhotoZShift,
+    PhotoZShiftandStretch,
     PTNonLinearBiasSystematic,
 )
 
 __all__ = [
-    "NumberCounts",
-    "NumberCountsFactory",
-    "PhotoZShift",
     "ConstantMagnificationBiasSystematic",
-    "PTNonLinearBiasSystematic",
+    "ConstantMagnificationBiasSystematicFactory",
+    "LinearBiasSystematic",
+    "LinearBiasSystematicFactory",
     "MagnificationBiasSystematic",
+    "MagnificationBiasSystematicFactory",
+    "NumberCounts",
+    "NumberCountsArgs",
+    "NumberCountsFactory",
+    "NumberCountsSystematic",
+    "NumberCountsSystematicFactory",
+    "PhotoZShift",
+    "PhotoZShiftandStretch",
+    "PTNonLinearBiasSystematic",
+    "PTNonLinearBiasSystematicFactory",
 ]

--- a/firecrown/likelihood/weak_lensing/__init__.py
+++ b/firecrown/likelihood/weak_lensing/__init__.py
@@ -21,6 +21,7 @@ from firecrown.likelihood._weak_lensing import (
     WeakLensingArgs,
     WeakLensingFactory,
     WeakLensingSystematic,
+    WeakLensingSystematicFactory,
 )
 
 # Re-export shared factories from base module
@@ -47,4 +48,5 @@ __all__ = [
     "WeakLensingArgs",
     "WeakLensingFactory",
     "WeakLensingSystematic",
+    "WeakLensingSystematicFactory",
 ]

--- a/firecrown/metadata_types/__init__.py
+++ b/firecrown/metadata_types/__init__.py
@@ -6,6 +6,10 @@ This module contains metadata types definitions.
 # Import all public types and classes from private submodules
 from firecrown.metadata_types._compatibility import (
     measurement_is_compatible,
+    measurement_is_compatible_harmonic,
+    measurement_is_compatible_real,
+    measurement_supports_harmonic,
+    measurement_supports_real,
     measurements_types,
 )
 from firecrown.metadata_types._inferred_galaxy_zdist import InferredGalaxyZDist
@@ -90,8 +94,12 @@ __all__ = [
     "TwoPointReal",
     "TwoPointCorrelationSpace",
     "TwoPointFilterMethod",
-    # Compatibility function (public)
+    # Compatibility functions (public)
     "measurement_is_compatible",
+    "measurement_is_compatible_harmonic",
+    "measurement_is_compatible_real",
+    "measurement_supports_harmonic",
+    "measurement_supports_real",
     "measurements_types",
     # SACC conversion constant
     "MEASURED_TYPE_STRING_MAP",

--- a/firecrown/metadata_types/_compatibility.py
+++ b/firecrown/metadata_types/_compatibility.py
@@ -37,12 +37,12 @@ def measurement_is_compatible(a: Measurement, b: Measurement) -> bool:
     return True
 
 
-def _measurement_supports_real(x: Measurement) -> bool:
+def measurement_supports_real(x: Measurement) -> bool:
     """Return True if x supports real-space calculations."""
     return x not in HARMONIC_ONLY_MEASUREMENTS
 
 
-def _measurement_supports_harmonic(x: Measurement) -> bool:
+def measurement_supports_harmonic(x: Measurement) -> bool:
     """Return True if x supports harmonic-space calculations."""
     return x not in REAL_ONLY_MEASUREMENTS
 
@@ -54,8 +54,8 @@ def measurement_is_compatible_real(a: Measurement, b: Measurement) -> bool:
     function.
     """
     return (
-        _measurement_supports_real(a)
-        and _measurement_supports_real(b)
+        measurement_supports_real(a)
+        and measurement_supports_real(b)
         and measurement_is_compatible(a, b)
     )
 
@@ -67,8 +67,8 @@ def measurement_is_compatible_harmonic(a: Measurement, b: Measurement) -> bool:
     two-point function.
     """
     return (
-        _measurement_supports_harmonic(a)
-        and _measurement_supports_harmonic(b)
+        measurement_supports_harmonic(a)
+        and measurement_supports_harmonic(b)
         and measurement_is_compatible(a, b)
     )
 

--- a/firecrown/models/two_point/_power_spectrum.py
+++ b/firecrown/models/two_point/_power_spectrum.py
@@ -10,7 +10,7 @@ import pyccl
 from firecrown.modeling_tools import ModelingTools
 
 if TYPE_CHECKING:
-    from firecrown.likelihood._base import Tracer
+    from firecrown.likelihood import Tracer
 
 
 def calculate_pk(

--- a/firecrown/models/two_point/_theory.py
+++ b/firecrown/models/two_point/_theory.py
@@ -19,7 +19,7 @@ from firecrown.models.two_point._interpolation import ApplyInterpolationWhen
 from firecrown.models.two_point._sacc_utils import determine_ccl_kind
 
 if TYPE_CHECKING:
-    from firecrown.likelihood._base import Source, Tracer
+    from firecrown.likelihood import Source, Tracer
 
 
 class TwoPointTheory(Updatable):

--- a/tests/app/analysis/test_analysis_builder.py
+++ b/tests/app/analysis/test_analysis_builder.py
@@ -8,8 +8,8 @@ from unittest.mock import patch
 import pytest
 
 from firecrown.likelihood import NamedParameters
-from firecrown.app.analysis._analysis_builder import AnalysisBuilder
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
+    AnalysisBuilder,
     Frameworks,
     FrameworkCosmology,
     CCLCosmologySpec,

--- a/tests/app/analysis/test_cobaya.py
+++ b/tests/app/analysis/test_cobaya.py
@@ -17,7 +17,7 @@ from firecrown.app.analysis._cobaya import (
     CobayaConfigGenerator,
     NAME_MAP,
 )
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
     Frameworks,
     FrameworkCosmology,
     CCLCosmologySpec,

--- a/tests/app/analysis/test_cosmosis.py
+++ b/tests/app/analysis/test_cosmosis.py
@@ -24,7 +24,7 @@ from firecrown.app.analysis._cosmosis import (
     NAME_MAP,
     COSMOLOGICAL_PARAMETERS,
 )
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
     Frameworks,
     FrameworkCosmology,
     CCLCosmologySpec,

--- a/tests/app/analysis/test_numcosmo_config.py
+++ b/tests/app/analysis/test_numcosmo_config.py
@@ -14,7 +14,7 @@ from firecrown.app.analysis._numcosmo import (
     ConfigOptions,
     _create_mapping,
 )
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
     FrameworkCosmology,
     CCLCosmologySpec,
 )

--- a/tests/app/analysis/test_numcosmo_generator.py
+++ b/tests/app/analysis/test_numcosmo_generator.py
@@ -17,7 +17,7 @@ from firecrown.app.analysis._numcosmo import (
     NumCosmoConfigGenerator,
     _set_standard_params,
 )
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
     Frameworks,
     FrameworkCosmology,
     CCLCosmologySpec,

--- a/tests/app/analysis/test_numcosmo_integration.py
+++ b/tests/app/analysis/test_numcosmo_integration.py
@@ -15,7 +15,7 @@ from firecrown.app.analysis._numcosmo import (
     NumCosmoConfigGenerator,
     NAME_MAP,
 )
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
     FrameworkCosmology,
     CCLCosmologySpec,
     Parameter,

--- a/tests/app/analysis/test_numcosmo_parameters.py
+++ b/tests/app/analysis/test_numcosmo_parameters.py
@@ -18,7 +18,7 @@ from firecrown.app.analysis._numcosmo import (
     _set_amplitude_sigma8,
     _set_neutrino_masses,
 )
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
     FrameworkCosmology,
     CCLCosmologySpec,
     Parameter,

--- a/tests/app/analysis/test_numcosmo_priors.py
+++ b/tests/app/analysis/test_numcosmo_priors.py
@@ -15,7 +15,7 @@ from firecrown.app.analysis._numcosmo import (
     _param_to_nc_dict,
     _setup_models,
 )
-from firecrown.app.analysis._types import (
+from firecrown.app.analysis import (
     FrameworkCosmology,
     CCLCosmologySpec,
     Parameter,

--- a/tests/app/analysis/test_numcosmo_utils.py
+++ b/tests/app/analysis/test_numcosmo_utils.py
@@ -11,7 +11,7 @@ from firecrown.app.analysis._numcosmo import (
     _param_to_nc_dict,
     _to_pascal,
 )
-from firecrown.app.analysis._types import Parameter
+from firecrown.app.analysis import Parameter
 
 
 @pytest.fixture(name="sample_parameter")

--- a/tests/app/analysis/test_types.py
+++ b/tests/app/analysis/test_types.py
@@ -21,7 +21,7 @@ from firecrown.app.analysis._types import (
     PoweSpecAmplitudeParameter,
     get_path_str,
 )
-from firecrown.app.analysis._cobaya import CobayaConfigGenerator
+from firecrown.app.analysis import CobayaConfigGenerator
 from firecrown.likelihood import NamedParameters
 from firecrown.modeling_tools import CAMBExtraParams
 

--- a/tests/app/examples/test_cosmic_shear.py
+++ b/tests/app/examples/test_cosmic_shear.py
@@ -10,7 +10,7 @@ import importlib.util
 
 from firecrown.likelihood import NamedParameters, ConstGaussian
 from firecrown.modeling_tools import ModelingTools
-from firecrown.app.examples._cosmic_shear import ExampleCosmicShear
+from firecrown.app.examples import ExampleCosmicShear
 from firecrown.app.analysis import (
     FrameworkCosmology,
     Frameworks,

--- a/tests/app/examples/test_sn_srd.py
+++ b/tests/app/examples/test_sn_srd.py
@@ -10,7 +10,7 @@ import importlib.util
 
 from firecrown.likelihood import NamedParameters, ConstGaussian
 from firecrown.modeling_tools import ModelingTools
-from firecrown.app.examples._sn_srd import ExampleSupernovaSRD
+from firecrown.app.examples import ExampleSupernovaSRD
 from firecrown.app.analysis import (
     Model,
     Parameter,

--- a/tests/app/sacc/test_utils.py
+++ b/tests/app/sacc/test_utils.py
@@ -6,7 +6,7 @@ Tests for utility functions used in SACC operations.
 import pytest
 import numpy as np
 from firecrown import metadata_types as mdt
-from firecrown.app.sacc._utils import mean_std_tracer
+from firecrown.app.sacc import mean_std_tracer
 
 
 @pytest.fixture(name="mock_tracer")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import numpy.typing as npt
 
 from firecrown.updatable import get_default_params_map
 from firecrown.utils import upper_triangle_indices
-from firecrown.likelihood._statistic import TrivialStatistic
+from firecrown.likelihood import TrivialStatistic
 from firecrown.updatable import ParamsMap
 from firecrown.connector.mapping import MappingCosmoSIS, mapping_builder
 from firecrown.modeling_tools import ModelingTools
@@ -32,17 +32,17 @@ from firecrown.metadata_types import (
     TwoPointReal,
     ALL_MEASUREMENTS,
 )
-from firecrown.metadata_types._compatibility import (
+from firecrown.metadata_types import (
     measurement_is_compatible_harmonic,
     measurement_is_compatible_real,
-    _measurement_supports_real,
-    _measurement_supports_harmonic,
+    measurement_supports_real,
+    measurement_supports_harmonic,
 )
 from firecrown.data_types import TwoPointMeasurement
-import firecrown.likelihood._weak_lensing as wl
+import firecrown.likelihood.weak_lensing as wl
 import firecrown.likelihood.number_counts as nc
-import firecrown.likelihood._two_point as tp
-import firecrown.likelihood._cmb as cmb
+from firecrown.likelihood import TwoPointFactory, CMBConvergenceFactory
+from firecrown.metadata_types import TwoPointCorrelationSpace
 from firecrown.metadata_types import Clusters, CMB
 
 # Helper function for creating AST ClassDef nodes across Python versions
@@ -1292,13 +1292,13 @@ def fixture_nc_factory() -> nc.NumberCountsFactory:
 @pytest.fixture(name="tp_factory")
 def fixture_tp_factory(
     wl_factory: wl.WeakLensingFactory, nc_factory: nc.NumberCountsFactory
-) -> tp.TwoPointFactory:
+) -> TwoPointFactory:
     """Generate a TwoPointFactory object."""
-    return tp.TwoPointFactory(
-        correlation_space=tp.TwoPointCorrelationSpace.REAL,
+    return TwoPointFactory(
+        correlation_space=TwoPointCorrelationSpace.REAL,
         weak_lensing_factories=[wl_factory],
         number_counts_factories=[nc_factory],
-        cmb_factories=[cmb.CMBConvergenceFactory()],
+        cmb_factories=[CMBConvergenceFactory()],
     )
 
 
@@ -1330,10 +1330,10 @@ def _discover_measurements_by_space():
     real_measurements = [
         m
         for m in supported_measurements
-        if _measurement_supports_real(m) and m != CMB.CONVERGENCE
+        if measurement_supports_real(m) and m != CMB.CONVERGENCE
     ]
     harmonic_measurements = [
-        m for m in supported_measurements if _measurement_supports_harmonic(m)
+        m for m in supported_measurements if measurement_supports_harmonic(m)
     ]
 
     return real_measurements, harmonic_measurements

--- a/tests/connector/cobaya/test_model_likelihood.py
+++ b/tests/connector/cobaya/test_model_likelihood.py
@@ -8,10 +8,8 @@ import numpy as np
 from cobaya.model import get_model, Model
 from cobaya.log import LoggedError
 from firecrown.connector.cobaya.likelihood import LikelihoodConnector
-from firecrown.likelihood._likelihood import NamedParameters
-from firecrown.likelihood._gaussian import ConstGaussian
+from firecrown.likelihood import TrivialStatistic, ConstGaussian, NamedParameters
 from firecrown.modeling_tools import ModelingTools
-import firecrown.likelihood._statistic as stat
 import firecrown.modeling_tools as ccl_factory
 
 
@@ -278,7 +276,7 @@ def test_derived_parameter_likelihood(fiducial_params):
 
 
 def _factory_as(_: NamedParameters):
-    return ConstGaussian([stat.TrivialStatistic()]), ModelingTools(
+    return ConstGaussian([TrivialStatistic()]), ModelingTools(
         ccl_factory=ccl_factory.CCLFactory(
             amplitude_parameter=ccl_factory.PoweSpecAmplitudeParameter.AS
         )
@@ -286,7 +284,7 @@ def _factory_as(_: NamedParameters):
 
 
 def _factory_sigma8(_: NamedParameters):
-    return ConstGaussian([stat.TrivialStatistic()]), ModelingTools(
+    return ConstGaussian([TrivialStatistic()]), ModelingTools(
         ccl_factory=ccl_factory.CCLFactory(
             amplitude_parameter=ccl_factory.PoweSpecAmplitudeParameter.SIGMA8
         )

--- a/tests/connector/cosmosis/test_cosmosis_module.py
+++ b/tests/connector/cosmosis/test_cosmosis_module.py
@@ -13,7 +13,7 @@ import numpy as np
 import pyccl
 from cosmosis.datablock import DataBlock, option_section, names as section_names
 
-from firecrown.likelihood._likelihood import NamedParameters
+from firecrown.likelihood import NamedParameters
 from firecrown.connector.cosmosis.likelihood import (
     FirecrownLikelihood,
     MissingSamplerParameterError,

--- a/tests/connector/numcosmo/test_numcosmo_connector.py
+++ b/tests/connector/numcosmo/test_numcosmo_connector.py
@@ -10,7 +10,7 @@ from firecrown.connector.numcosmo.numcosmo import (
     NumCosmoGaussCov,
 )
 
-from firecrown.likelihood._likelihood import (
+from firecrown.likelihood import (
     NamedParameters,
     Likelihood,
 )

--- a/tests/connector/numcosmo/test_numcosmo_mapping.py
+++ b/tests/connector/numcosmo/test_numcosmo_mapping.py
@@ -6,8 +6,7 @@ import pytest
 import pyccl as ccl
 from numcosmo_py import Ncm, Nc, GObject
 
-from firecrown.likelihood._likelihood import Likelihood, NamedParameters
-from firecrown.likelihood._gaussian import ConstGaussian
+from firecrown.likelihood import ConstGaussian, Likelihood, NamedParameters
 from firecrown.modeling_tools import ModelingTools
 from firecrown.connector.numcosmo.numcosmo import (
     NumCosmoData,

--- a/tests/connector/test_mapping.py
+++ b/tests/connector/test_mapping.py
@@ -12,7 +12,7 @@ from firecrown.connector.mapping import (
     MappingCosmoSIS,
     MappingCAMB,
 )
-from firecrown.likelihood._likelihood import NamedParameters
+from firecrown.likelihood import NamedParameters
 from firecrown.modeling_tools import PoweSpecAmplitudeParameter
 from firecrown.updatable import ParamsMap
 

--- a/tests/fctools/test_measurement_compatibility.py
+++ b/tests/fctools/test_measurement_compatibility.py
@@ -19,12 +19,10 @@ from firecrown.fctools.measurement_compatibility import (
 from firecrown.metadata_types import (
     ALL_MEASUREMENTS,
     Measurement,
-)
-from firecrown.metadata_types._compatibility import (
     measurement_is_compatible_harmonic,
     measurement_is_compatible_real,
-    _measurement_supports_harmonic as measurement_supports_harmonic,
-    _measurement_supports_real as measurement_supports_real,
+    measurement_supports_harmonic,
+    measurement_supports_real,
 )
 
 from . import match_wrapped

--- a/tests/likelihood/gauss_family/lkscript_const_gaussian.py
+++ b/tests/likelihood/gauss_family/lkscript_const_gaussian.py
@@ -5,8 +5,7 @@ for testing purposes.
 
 import sacc
 
-from firecrown.likelihood._gaussian import ConstGaussian
-from firecrown.likelihood.supernova._supernova import Supernova
+from firecrown.likelihood import ConstGaussian, Supernova
 from firecrown.modeling_tools import ModelingTools
 from firecrown.modeling_tools import CCLFactory, PoweSpecAmplitudeParameter
 

--- a/tests/likelihood/gauss_family/lkscript_two_point.py
+++ b/tests/likelihood/gauss_family/lkscript_two_point.py
@@ -6,9 +6,7 @@ for testing purposes.
 import numpy as np
 import sacc
 
-from firecrown.likelihood._likelihood import NamedParameters
-from firecrown.likelihood._gaussian import ConstGaussian
-from firecrown.likelihood._two_point import TwoPoint
+from firecrown.likelihood import NamedParameters, ConstGaussian, TwoPoint
 from firecrown.likelihood.number_counts import (
     NumberCounts,
 )

--- a/tests/likelihood/gauss_family/lkscript_two_point_pure_ccl.py
+++ b/tests/likelihood/gauss_family/lkscript_two_point_pure_ccl.py
@@ -6,9 +6,7 @@ for testing purposes.
 import numpy as np
 import sacc
 
-from firecrown.likelihood._likelihood import NamedParameters
-from firecrown.likelihood._gaussian import ConstGaussian
-from firecrown.likelihood._two_point import TwoPoint
+from firecrown.likelihood import NamedParameters, ConstGaussian, TwoPoint
 from firecrown.likelihood.number_counts import (
     NumberCounts,
 )

--- a/tests/likelihood/gauss_family/statistic/source/test_source.py
+++ b/tests/likelihood/gauss_family/statistic/source/test_source.py
@@ -16,12 +16,10 @@ from numpy.testing import assert_allclose
 from scipy.interpolate import Akima1DInterpolator
 
 import firecrown.likelihood.number_counts as nc
-import firecrown.likelihood.number_counts._factories as nc_factories
-import firecrown.likelihood.number_counts._systematics as nc_sys
-import firecrown.likelihood._weak_lensing as wl
-from firecrown.likelihood.number_counts._args import NumberCountsArgs
-from firecrown.likelihood._weak_lensing import WeakLensingArgs
-from firecrown.likelihood._source import (
+import firecrown.likelihood.weak_lensing as wl
+from firecrown.likelihood.number_counts import NumberCountsArgs
+from firecrown.likelihood.weak_lensing import WeakLensingArgs
+from firecrown.likelihood import (
     SourceGalaxy,
     SourceGalaxyArgs,
     SourceGalaxySelectField,
@@ -38,12 +36,12 @@ from firecrown.updatable import get_default_params
 @pytest.fixture(
     name="nc_sys_factory",
     params=[
-        nc_factories.PhotoZShiftFactory(),
-        nc_factories.PhotoZShiftandStretchFactory(),
-        nc_factories.LinearBiasSystematicFactory(),
-        nc_factories.PTNonLinearBiasSystematicFactory(),
-        nc_factories.MagnificationBiasSystematicFactory(),
-        nc_factories.ConstantMagnificationBiasSystematicFactory(),
+        wl.PhotoZShiftFactory(),
+        wl.PhotoZShiftandStretchFactory(),
+        nc.LinearBiasSystematicFactory(),
+        nc.PTNonLinearBiasSystematicFactory(),
+        nc.MagnificationBiasSystematicFactory(),
+        nc.ConstantMagnificationBiasSystematicFactory(),
     ],
     ids=[
         "PhotoZShiftFactory",
@@ -54,7 +52,7 @@ from firecrown.updatable import get_default_params
         "ConstantMagnificationBiasSystematicFactory",
     ],
 )
-def fixture_nc_sys_factory(request) -> nc_factories.NumberCountsSystematicFactory:
+def fixture_nc_sys_factory(request) -> nc.NumberCountsSystematicFactory:
     """Fixture for the NumberCountsSystematicFactory class."""
     return request.param
 
@@ -123,8 +121,8 @@ def test_tracer_construction_with_name(empty_pyccl_tracer):
 
 
 def test_nc_linear_bias_systematic():
-    a = nc_sys.LinearBiasSystematic("xxx")
-    assert isinstance(a, nc_sys.LinearBiasSystematic)
+    a = nc.LinearBiasSystematic("xxx")
+    assert isinstance(a, nc.LinearBiasSystematic)
     assert a.parameter_prefix == "xxx"
     assert a.alphag is None
     assert a.alphaz is None
@@ -148,7 +146,7 @@ def test_nc_linear_bias_systematic():
 def test_nc_nonlinear_bias_systematic_tracer_args_missing(
     tools_with_vanilla_cosmology: ModelingTools,
 ):
-    a = nc_sys.LinearBiasSystematic("xxx")
+    a = nc.LinearBiasSystematic("xxx")
     # The values in the ParamsMap and the tracer_args are set to allow easy verification
     # that a tracer_args of None is handled correctly.
     a.update(ParamsMap({"xxx_alphag": 1.0, "xxx_alphaz": 1.0, "xxx_z_piv": 0.0}))
@@ -358,7 +356,7 @@ def test_number_counts_source_factory_global_systematics(sacc_galaxy_cells_lens0
     lens0 = next((obj for obj in all_tracers if obj.bin_name == "lens0"), None)
     assert lens0 is not None
 
-    global_systematics = [nc_factories.PTNonLinearBiasSystematicFactory()]
+    global_systematics = [nc.PTNonLinearBiasSystematicFactory()]
     nc_factory = nc.NumberCountsFactory(
         per_bin_systematics=[],
         global_systematics=global_systematics,
@@ -386,7 +384,7 @@ def test_number_counts_source_init_wrong_name(sacc_galaxy_cells_lens0_lens0):
 
 
 def test_number_counts_systematic_factory(
-    nc_sys_factory: nc_factories.NumberCountsSystematicFactory,
+    nc_sys_factory: nc.NumberCountsSystematicFactory,
 ):
     sys_pz_shift = nc_sys_factory.create("bin_1")
     assert sys_pz_shift.parameter_prefix == "bin_1"
@@ -411,25 +409,25 @@ def test_wl_multiplicativeshearbiasfactory_no_globals():
 
 
 def test_nc_photozshiftfactory_no_globals():
-    factory = nc_factories.PhotoZShiftFactory()
+    factory = wl.PhotoZShiftFactory()
     with pytest.raises(ValueError, match="PhotoZShift cannot be global"):
         _ = factory.create_global()
 
 
 def test_nc_photozshiftandstretchfactory_no_globals():
-    factory = nc_factories.PhotoZShiftandStretchFactory()
+    factory = wl.PhotoZShiftandStretchFactory()
     with pytest.raises(ValueError, match="PhotoZShiftandStretch cannot be global"):
         _ = factory.create_global()
 
 
 def test_nc_linearbiassystematicfactory_no_globals():
-    factory = nc_factories.LinearBiasSystematicFactory()
+    factory = nc.LinearBiasSystematicFactory()
     with pytest.raises(ValueError, match="LinearBiasSystematic cannot be global"):
         _ = factory.create_global()
 
 
 def test_nc_magnificationbiassystematicfactory_no_globals():
-    factory = nc_factories.MagnificationBiasSystematicFactory()
+    factory = nc.MagnificationBiasSystematicFactory()
     with pytest.raises(
         ValueError, match="MagnificationBiasSystematic cannot be global"
     ):
@@ -437,7 +435,7 @@ def test_nc_magnificationbiassystematicfactory_no_globals():
 
 
 def test_nc_constantmagnificationbiassystematicfactory_no_globals():
-    factory = nc_factories.ConstantMagnificationBiasSystematicFactory()
+    factory = nc.ConstantMagnificationBiasSystematicFactory()
     with pytest.raises(
         ValueError, match="ConstantMagnificationBiasSystematic cannot be global"
     ):
@@ -489,8 +487,8 @@ def test_wl_photozshiftandstretch_systematic(
 def test_nc_photozshiftandstretch_systematic(
     tools_with_vanilla_cosmology: ModelingTools,
 ):
-    a = nc_sys.PhotoZShiftandStretch("xxx")
-    assert isinstance(a, nc_sys.PhotoZShiftandStretch)
+    a = nc.PhotoZShiftandStretch("xxx")
+    assert isinstance(a, nc.PhotoZShiftandStretch)
     assert a.parameter_prefix == "xxx"
     assert a.delta_z is None
     assert a.sigma_z is None
@@ -586,7 +584,7 @@ def test_dndz_shift_and_stretch_passive_negative_sigma():
 def test_photoz_shift(
     tools_with_vanilla_cosmology: ModelingTools, shift: float, active: bool
 ):
-    photoz_shift = nc_sys.PhotoZShift("John", active=active)
+    photoz_shift = nc.PhotoZShift("John", active=active)
     photoz_shift.update(ParamsMap({"John_delta_z": shift}))
     sigma = 0.05
     mu = 0.5
@@ -618,7 +616,7 @@ def test_photoz_shift_stretch(
     stretch: float,
     active: bool,
 ):
-    photoz_shift_stretch = nc_sys.PhotoZShiftandStretch("John", active=active)
+    photoz_shift_stretch = nc.PhotoZShiftandStretch("John", active=active)
     photoz_shift_stretch.update(
         ParamsMap({"John_delta_z": shift, "John_sigma_z": stretch})
     )

--- a/tests/likelihood/gauss_family/statistic/test_binned_cluster_number_counts.py
+++ b/tests/likelihood/gauss_family/statistic/test_binned_cluster_number_counts.py
@@ -8,11 +8,8 @@ from crow.properties import ClusterProperty
 from crow.recipes.binned_exact import ExactBinnedClusterRecipe
 from crow.recipes.binned_grid import GridBinnedClusterRecipe
 
-from firecrown.likelihood._binned_cluster_number_counts import BinnedClusterNumberCounts
-from firecrown.likelihood._binned_cluster_number_counts_shear import (
-    BinnedClusterShearProfile,
-)
-from firecrown.likelihood._source import SourceSystematic
+from firecrown.likelihood import BinnedClusterNumberCounts, BinnedClusterShearProfile
+from firecrown.likelihood import SourceSystematic
 from firecrown.modeling_tools import ModelingTools
 from firecrown.updatable import get_default_params_map
 

--- a/tests/likelihood/gauss_family/statistic/test_two_point.py
+++ b/tests/likelihood/gauss_family/statistic/test_two_point.py
@@ -18,22 +18,19 @@ from firecrown.updatable import get_default_params_map
 from firecrown.modeling_tools import ModelingTools
 from firecrown.updatable import ParamsMap
 
-from firecrown.likelihood.number_counts import (
-    NumberCounts,
-)
-from firecrown.likelihood._weak_lensing import (
-    WeakLensing,
-)
+from firecrown.likelihood.number_counts import NumberCounts
+from firecrown.likelihood.weak_lensing import WeakLensing, WeakLensingFactory
 import firecrown.metadata_types as mdt
-import firecrown.likelihood._two_point as tp
-from firecrown.likelihood._two_point import (
-    NumberCountsFactory,
+from firecrown.likelihood.number_counts import NumberCountsFactory
+from firecrown.likelihood.factories import (
     TwoPointFactory,
     use_source_factory,
     use_source_factory_metadata_index,
 )
-from firecrown.models.two_point import TwoPointTheory
-from firecrown.generators._two_point import (
+from firecrown.likelihood import TwoPoint
+from firecrown.models.two_point import ApplyInterpolationWhen, TwoPointTheory
+import firecrown.models.two_point as tp
+from firecrown.generators import (
     generate_bin_centers,
     EllOrThetaConfig,
     LogLinearElls,
@@ -72,9 +69,9 @@ def fixture_tools() -> ModelingTools:
 @pytest.fixture(name="two_point_with_window")
 def fixture_two_point_with_window(
     harmonic_data_with_window: TwoPointMeasurement, tp_factory: TwoPointFactory
-) -> tp.TwoPoint:
+) -> TwoPoint:
     """Return a TwoPoint object with a window."""
-    two_points = tp.TwoPoint.from_measurement(
+    two_points = TwoPoint.from_measurement(
         [harmonic_data_with_window], tp_factory=tp_factory
     )
     return two_points.pop()
@@ -83,16 +80,16 @@ def fixture_two_point_with_window(
 @pytest.fixture(name="two_point_without_window")
 def fixture_two_point_without_window(
     harmonic_data_no_window: TwoPointMeasurement, tp_factory: TwoPointFactory
-) -> tp.TwoPoint:
+) -> TwoPoint:
     """Return a TwoPoint object without a window."""
-    two_points = tp.TwoPoint.from_measurement(
+    two_points = TwoPoint.from_measurement(
         [harmonic_data_no_window], tp_factory=tp_factory
     )
     return two_points.pop()
 
 
-@pytest.fixture(name="apply_interp_when", params=list(tp.ApplyInterpolationWhen))
-def fixture_apply_interp_when(request) -> tp.ApplyInterpolationWhen:
+@pytest.fixture(name="apply_interp_when", params=list(ApplyInterpolationWhen))
+def fixture_apply_interp_when(request) -> ApplyInterpolationWhen:
     return request.param
 
 
@@ -129,8 +126,8 @@ def test_log_linear_ells_generate_all() -> None:
 
 def test_compute_theory_vector(source_0: NumberCounts) -> None:
     # To create the TwoPoint object we need at least one source.
-    statistic = tp.TwoPoint("galaxy_density_xi", source_0, source_0)
-    assert isinstance(statistic, tp.TwoPoint)
+    statistic = TwoPoint("galaxy_density_xi", source_0, source_0)
+    assert isinstance(statistic, TwoPoint)
 
     # Before calling compute_theory_vector, we must get the TwoPoint object
     # into the correct state.
@@ -139,13 +136,13 @@ def test_compute_theory_vector(source_0: NumberCounts) -> None:
 
 
 def test_tracer_names() -> None:
-    assert tp.TracerNames("", "") == mdt.TRACER_NAMES_TOTAL
+    assert mdt.TracerNames("", "") == mdt.TRACER_NAMES_TOTAL
 
-    tn1 = tp.TracerNames("cow", "pig")
+    tn1 = mdt.TracerNames("cow", "pig")
     assert tn1[0] == "cow"
     assert tn1[1] == "pig"
 
-    tn2 = tp.TracerNames("cat", "dog")
+    tn2 = mdt.TracerNames("cat", "dog")
     assert tn1 != tn2
     assert hash(tn1) != hash(tn2)
 
@@ -168,7 +165,7 @@ def test_two_point_src0_src0_window_parameterized(
 
     src0 = WeakLensing(sacc_tracer="src0")
 
-    statistic = tp.TwoPoint("galaxy_shear_cl_ee", src0, src0)
+    statistic = TwoPoint("galaxy_shear_cl_ee", src0, src0)
     statistic.read(sacc_data)
 
     tools = ModelingTools()
@@ -228,7 +225,7 @@ def test_two_point_src0_src0_no_data_binning(
         "binning": binning_type,
     }
 
-    statistic = tp.TwoPoint(
+    statistic = TwoPoint(
         "galaxy_shear_cl_ee",
         src0,
         src0,
@@ -257,7 +254,7 @@ def test_two_point_lens0_lens0_no_data(sacc_galaxy_xis_lens0_lens0_no_data) -> N
         "binning": "lin",
     }
 
-    statistic = tp.TwoPoint(
+    statistic = TwoPoint(
         "galaxy_density_xi",
         src0,
         src0,
@@ -338,7 +335,7 @@ def test_two_point_lens0_lens0_config(sacc_galaxy_xis_lens0_lens0) -> None:
 
     src0 = NumberCounts(sacc_tracer="lens0")
 
-    statistic = tp.TwoPoint(
+    statistic = TwoPoint(
         "galaxy_density_xi",
         src0,
         src0,
@@ -370,7 +367,7 @@ def test_two_point_src0_src0_no_data_error(sacc_galaxy_cells_src0_src0_no_data) 
 
     src0 = WeakLensing(sacc_tracer="src0")
 
-    statistic = tp.TwoPoint("galaxy_shear_cl_ee", src0, src0)
+    statistic = TwoPoint("galaxy_shear_cl_ee", src0, src0)
     with pytest.warns(UserWarning, match="Empty index selected"):
         with pytest.raises(
             RuntimeError,
@@ -389,7 +386,7 @@ def test_two_point_lens0_lens0_no_data_error(
 
     src0 = NumberCounts(sacc_tracer="lens0")
 
-    statistic = tp.TwoPoint("galaxy_density_xi", src0, src0)
+    statistic = TwoPoint("galaxy_density_xi", src0, src0)
     with pytest.warns(UserWarning, match="Empty index selected"):
         with pytest.raises(
             RuntimeError,
@@ -415,7 +412,7 @@ def test_two_point_src0_src0_data_and_conf_warn(
         "binning": "lin",
     }
 
-    statistic = tp.TwoPoint("galaxy_shear_cl_ee", src0, src0, ell_or_theta=ell_config)
+    statistic = TwoPoint("galaxy_shear_cl_ee", src0, src0, ell_or_theta=ell_config)
     with pytest.warns(
         UserWarning,
         match=re.escape(
@@ -438,7 +435,7 @@ def test_two_point_lens0_lens0_data_and_conf_warn(sacc_galaxy_xis_lens0_lens0) -
         "binning": "lin",
     }
 
-    statistic = tp.TwoPoint("galaxy_density_xi", src0, src0, ell_or_theta=theta_config)
+    statistic = TwoPoint("galaxy_density_xi", src0, src0, ell_or_theta=theta_config)
     with pytest.warns(
         UserWarning,
         match=re.escape(
@@ -491,7 +488,7 @@ def test_use_source_factory_metadata_only_shear(tp_factory: TwoPointFactory) -> 
         "bin1", Galaxies.SHEAR_E, tp_factory=tp_factory
     )
     factory = tp_factory.get_factory(Galaxies.SHEAR_E)
-    assert isinstance(factory, tp.WeakLensingFactory)
+    assert isinstance(factory, WeakLensingFactory)
     assert isinstance(source, WeakLensing)
 
 
@@ -504,7 +501,7 @@ def test_use_source_factory_metadata_only_invalid_measurement(
 
 def test_two_point_wrong_type() -> None:
     with pytest.raises(ValueError, match="The SACC data type cow is not supported!"):
-        tp.TwoPoint(
+        TwoPoint(
             "cow", WeakLensing(sacc_tracer="calma"), WeakLensing(sacc_tracer="fernando")
         )
 
@@ -513,7 +510,7 @@ def test_from_metadata_harmonic_wrong_metadata(tp_factory: TwoPointFactory) -> N
     with pytest.raises(
         ValueError, match=re.escape("Metadata of type <class 'str'> is not supported")
     ):
-        tp.TwoPoint._from_metadata_single(  # pylint: disable=protected-access
+        TwoPoint._from_metadata_single(  # pylint: disable=protected-access
             metadata="NotAMetadata", tp_factory=tp_factory  # type: ignore
         )
 
@@ -531,29 +528,29 @@ def test_use_source_factory_metadata_only_wrong_measurement(
 def test_from_metadata_only_harmonic(tp_factory: TwoPointFactory) -> None:
     metadata: TwoPointHarmonicIndex = {
         "data_type": "galaxy_density_xi",
-        "tracer_names": tp.TracerNames("lens0", "lens0"),
+        "tracer_names": mdt.TracerNames("lens0", "lens0"),
         "tracer_types": (Galaxies.COUNTS, Galaxies.COUNTS),
     }
-    two_point = tp.TwoPoint.from_metadata_index([metadata], tp_factory).pop()
-    assert isinstance(two_point, tp.TwoPoint)
+    two_point = TwoPoint.from_metadata_index([metadata], tp_factory).pop()
+    assert isinstance(two_point, TwoPoint)
     assert not two_point.ready
 
 
 def test_from_metadata_only_real(tp_factory: TwoPointFactory) -> None:
     metadata: TwoPointRealIndex = {
         "data_type": "galaxy_shear_xi_plus",
-        "tracer_names": tp.TracerNames("src0", "src0"),
+        "tracer_names": mdt.TracerNames("src0", "src0"),
         "tracer_types": (Galaxies.PART_OF_XI_PLUS, Galaxies.PART_OF_XI_PLUS),
     }
-    two_point = tp.TwoPoint.from_metadata_index([metadata], tp_factory).pop()
-    assert isinstance(two_point, tp.TwoPoint)
+    two_point = TwoPoint.from_metadata_index([metadata], tp_factory).pop()
+    assert isinstance(two_point, TwoPoint)
     assert not two_point.ready
 
 
 def test_from_measurement_compute_theory_vector_window(
-    two_point_with_window: tp.TwoPoint,
+    two_point_with_window: TwoPoint,
 ) -> None:
-    assert isinstance(two_point_with_window, tp.TwoPoint)
+    assert isinstance(two_point_with_window, TwoPoint)
     assert two_point_with_window.ready
 
     tools = ModelingTools()
@@ -574,12 +571,12 @@ def test_from_measurement_compute_theory_vector_window(
 
 
 def test_from_measurement_compute_theory_vector_window_check(
-    two_point_with_window: tp.TwoPoint, two_point_without_window: tp.TwoPoint
+    two_point_with_window: TwoPoint, two_point_without_window: TwoPoint
 ) -> None:
-    assert isinstance(two_point_with_window, tp.TwoPoint)
+    assert isinstance(two_point_with_window, TwoPoint)
     assert two_point_with_window.ready
 
-    assert isinstance(two_point_without_window, tp.TwoPoint)
+    assert isinstance(two_point_without_window, TwoPoint)
     assert two_point_without_window.ready
 
     tools = ModelingTools()
@@ -715,7 +712,7 @@ def test_two_point_src0_src0_window_aiw(
 
     src0 = WeakLensing(sacc_tracer="src0")
 
-    statistic = tp.TwoPoint(
+    statistic = TwoPoint(
         "galaxy_shear_cl_ee", src0, src0, apply_interp=apply_interp_when
     )
     statistic.read(sacc_data)
@@ -747,7 +744,7 @@ def test_two_point_src0_src0_no_window_aiw(
 
     src0 = WeakLensing(sacc_tracer="src0")
 
-    statistic = tp.TwoPoint(
+    statistic = TwoPoint(
         "galaxy_shear_cl_ee", src0, src0, apply_interp=apply_interp_when
     )
     statistic.read(sacc_data)
@@ -780,7 +777,7 @@ def test_two_point_src0_src0_real_aiw(
     sacc_data, _, _ = sacc_galaxy_xis_lens0_lens0_real
 
     lens0 = WeakLensing(sacc_tracer="lens0")
-    statistic = tp.TwoPoint(
+    statistic = TwoPoint(
         "galaxy_density_xi", lens0, lens0, apply_interp=apply_interp_when
     )
     statistic.read(sacc_data)
@@ -867,7 +864,7 @@ def test_calculate_pk_with_halo_model():
 def test_two_point_normalize_window_default():
     """Test that TwoPoint.normalize_window defaults to True."""
     source = NumberCounts(sacc_tracer="lens_0")
-    two_point = tp.TwoPoint(
+    two_point = TwoPoint(
         sacc_data_type="galaxy_density_cl",
         source0=source,
         source1=source,
@@ -878,7 +875,7 @@ def test_two_point_normalize_window_default():
 def test_two_point_normalize_window_false():
     """Test that TwoPoint.normalize_window can be set to False."""
     source = NumberCounts(sacc_tracer="lens_0")
-    two_point = tp.TwoPoint(
+    two_point = TwoPoint(
         sacc_data_type="galaxy_density_cl",
         source0=source,
         source1=source,
@@ -890,7 +887,7 @@ def test_two_point_normalize_window_false():
 def test_two_point_normalize_window_true_explicit():
     """Test that TwoPoint.normalize_window can be explicitly set to True."""
     source = NumberCounts(sacc_tracer="lens_0")
-    two_point = tp.TwoPoint(
+    two_point = TwoPoint(
         sacc_data_type="galaxy_density_cl",
         source0=source,
         source1=source,
@@ -961,14 +958,14 @@ def test_two_point_normalize_window_used_in_read(sacc_with_window_for_two_point)
     # Create two TwoPoint objects: one with normalize_window=True, one False
     source = WeakLensing(sacc_tracer="src0")
 
-    two_point_normalized = tp.TwoPoint(
+    two_point_normalized = TwoPoint(
         sacc_data_type="galaxy_shear_cl_ee",
         source0=source,
         source1=source,
         normalize_window=True,
     )
 
-    two_point_unnormalized = tp.TwoPoint(
+    two_point_unnormalized = TwoPoint(
         sacc_data_type="galaxy_shear_cl_ee",
         source0=source,
         source1=source,

--- a/tests/likelihood/gauss_family/test_const_gaussian.py
+++ b/tests/likelihood/gauss_family/test_const_gaussian.py
@@ -11,16 +11,18 @@ from scipy.stats import chi2
 import sacc
 
 import firecrown.updatable
-from firecrown.likelihood._gaussian import ConstGaussian
-from firecrown.likelihood._gaussfamily import Statistic
-from firecrown.likelihood._statistic import TrivialStatistic
+from firecrown.likelihood import (
+    ConstGaussian,
+    Statistic,
+    TrivialStatistic,
+    TwoPoint,
+)
 from firecrown.modeling_tools import ModelingTools
 from firecrown.updatable import (
     RequiredParameters,
     DerivedParameterCollection,
     SamplerParameter,
 )
-from firecrown.likelihood._two_point import TwoPoint
 from firecrown.metadata_types import TracerNames, Galaxies
 from firecrown.metadata_functions import TwoPointHarmonicIndex
 from firecrown.data_functions import extract_all_harmonic_data

--- a/tests/likelihood/lkdir/lk_derived_parameter.py
+++ b/tests/likelihood/lkdir/lk_derived_parameter.py
@@ -3,7 +3,7 @@ Provides a trivial likelihood factory function for testing purposes.
 The likelihood created provides one derived parameter named "derived_param0".
 """
 
-from firecrown.likelihood._likelihood import NamedParameters
+from firecrown.likelihood import NamedParameters
 from firecrown.modeling_tools import ModelingTools
 from firecrown.modeling_tools import CCLFactory, PoweSpecAmplitudeParameter
 from . import lkmodule

--- a/tests/likelihood/lkdir/lk_needing_param.py
+++ b/tests/likelihood/lkdir/lk_needing_param.py
@@ -3,7 +3,7 @@ Provides a trivial likelihood factory function for testing purposes.
 The likelihood created requires a string parameter named "sacc_file".
 """
 
-from firecrown.likelihood._likelihood import NamedParameters
+from firecrown.likelihood import NamedParameters
 from firecrown.modeling_tools import ModelingTools
 from firecrown.modeling_tools import CCLFactory, PoweSpecAmplitudeParameter
 from . import lkmodule

--- a/tests/likelihood/lkdir/lk_sampler_parameter.py
+++ b/tests/likelihood/lkdir/lk_sampler_parameter.py
@@ -4,7 +4,7 @@ The likelihood created requires a string parameter named "parameter_prefix"
 and has a sampler parameter named "sampler_param0".
 """
 
-from firecrown.likelihood._likelihood import NamedParameters
+from firecrown.likelihood import NamedParameters
 from firecrown.modeling_tools import ModelingTools
 from firecrown.modeling_tools import CCLFactory, PoweSpecAmplitudeParameter
 from . import lkmodule

--- a/tests/likelihood/lkdir/lkmodule.py
+++ b/tests/likelihood/lkdir/lkmodule.py
@@ -4,7 +4,7 @@ Provides a trivial likelihood class and factory function for testing purposes.
 
 import sacc
 from firecrown.updatable import DerivedParameterCollection, DerivedParameter
-from firecrown.likelihood._likelihood import Likelihood, NamedParameters
+from firecrown.likelihood import Likelihood, NamedParameters
 from firecrown.modeling_tools import ModelingTools
 from firecrown import parameters
 

--- a/tests/likelihood/test_gauss_family.py
+++ b/tests/likelihood/test_gauss_family.py
@@ -3,7 +3,7 @@
 import re
 
 import pytest
-import firecrown.likelihood._gaussian as g
+from firecrown.likelihood import ConstGaussian
 
 
 def test_init_rejects_non_statistics():
@@ -13,4 +13,4 @@ def test_init_rejects_non_statistics():
             "statistics[0] is not an instance of Statistic. It is a <class 'int'>."
         ),
     ):
-        g.ConstGaussian([1])  # type: ignore[list-item]
+        ConstGaussian([1])  # type: ignore[list-item]

--- a/tests/metadata/test_metadata_two_point.py
+++ b/tests/metadata/test_metadata_two_point.py
@@ -27,15 +27,15 @@ from firecrown.metadata_types._sacc_type_string import (
     _type_to_sacc_string_real as real,
 )
 from firecrown.data_types import TwoPointMeasurement
-from firecrown.likelihood._source import SourceGalaxy
-from firecrown.likelihood._two_point import (
+from firecrown.likelihood import (
+    CMBConvergenceFactory,
+    SourceGalaxy,
     TwoPoint,
     TwoPointFactory,
-    TwoPointCorrelationSpace,
 )
-from firecrown.likelihood._cmb import CMBConvergenceFactory
-from firecrown.likelihood._weak_lensing import WeakLensingFactory
+from firecrown.likelihood.weak_lensing import WeakLensingFactory
 from firecrown.likelihood.number_counts import NumberCountsFactory
+from firecrown.metadata_types import TwoPointCorrelationSpace
 
 
 def test_inferred_galaxy_z_dist():

--- a/tests/metadata/test_metadata_two_point_types.py
+++ b/tests/metadata/test_metadata_two_point_types.py
@@ -27,11 +27,11 @@ from firecrown.metadata_types import (
     measurement_is_compatible as is_compatible,
     measurements_types,
 )
-from firecrown.metadata_types._compatibility import (
+from firecrown.metadata_types import (
     measurement_is_compatible_harmonic as is_compatible_harmonic,
     measurement_is_compatible_real as is_compatible_real,
-    _measurement_supports_harmonic as supports_harmonic,
-    _measurement_supports_real as supports_real,
+    measurement_supports_harmonic as supports_harmonic,
+    measurement_supports_real as supports_real,
 )
 from firecrown.metadata_types._sacc_type_string import (
     _type_to_sacc_string_harmonic as harmonic,

--- a/tests/test_bug_398.py
+++ b/tests/test_bug_398.py
@@ -18,11 +18,14 @@ import sacc
 from numpy.testing import assert_allclose
 
 from firecrown.updatable import get_default_params_map
-import firecrown.likelihood._weak_lensing as wl
-from firecrown.likelihood._two_point import TwoPoint
-from firecrown.likelihood._gaussian import ConstGaussian
+import firecrown.likelihood.weak_lensing as wl
+from firecrown.likelihood import (
+    ConstGaussian,
+    Likelihood,
+    NamedParameters,
+    TwoPoint,
+)
 from firecrown.modeling_tools import ModelingTools
-from firecrown.likelihood._likelihood import Likelihood, NamedParameters
 from firecrown.modeling_tools import CCLFactory, PoweSpecAmplitudeParameter
 
 

--- a/tests/test_bug_413.py
+++ b/tests/test_bug_413.py
@@ -5,14 +5,11 @@ import pyccl
 import sacc
 
 from firecrown.updatable import get_default_params_map
-from firecrown.likelihood.number_counts import NumberCounts
-from firecrown.likelihood.number_counts._systematics import (
-    PTNonLinearBiasSystematic,
-)
-from firecrown.likelihood._two_point import TwoPoint
+from firecrown.likelihood.number_counts import NumberCounts, PTNonLinearBiasSystematic
+from firecrown.likelihood import TwoPoint
 from firecrown.models.two_point import calculate_pk
 from firecrown.modeling_tools import ModelingTools
-import firecrown.generators._two_point as gen
+import firecrown.generators as gen
 
 
 def make_twopoint_with_optional_systematics(

--- a/tests/test_hm_systematics.py
+++ b/tests/test_hm_systematics.py
@@ -12,13 +12,10 @@ import pyccl as ccl
 import sacc
 
 from firecrown.updatable import get_default_params_map
-import firecrown.likelihood._weak_lensing as wl
+import firecrown.likelihood.weak_lensing as wl
 import firecrown.metadata_types as mdt
-from firecrown.likelihood._two_point import (
-    TwoPoint,
-    TracerNames,
-)
-from firecrown.likelihood._gaussian import ConstGaussian
+from firecrown.likelihood import ConstGaussian, TwoPoint
+from firecrown.metadata_types import TracerNames
 from firecrown.likelihood.factories import load_sacc_data
 from firecrown.modeling_tools import ModelingTools
 from firecrown.modeling_tools import CCLFactory

--- a/tests/test_pt_systematics.py
+++ b/tests/test_pt_systematics.py
@@ -14,16 +14,11 @@ import pyccl.nl_pt as pt
 import sacc
 
 from firecrown.updatable import get_default_params_map
-import firecrown.likelihood._weak_lensing as wl
+import firecrown.likelihood.weak_lensing as wl
 import firecrown.likelihood.number_counts as nc
-import firecrown.likelihood.number_counts._systematics as nc_sys
-import firecrown.likelihood.number_counts._args as nc_args
 import firecrown.metadata_types as mdt
-from firecrown.likelihood._two_point import (
-    TwoPoint,
-    TracerNames,
-)
-from firecrown.likelihood._gaussian import ConstGaussian
+from firecrown.likelihood import ConstGaussian, TwoPoint
+from firecrown.metadata_types import TracerNames
 from firecrown.modeling_tools import ModelingTools
 from firecrown.modeling_tools import CCLFactory, PoweSpecAmplitudeParameter
 import firecrown.updatable as fcp
@@ -38,9 +33,9 @@ def fixture_weak_lensing_source() -> wl.WeakLensing:
 
 @pytest.fixture(name="number_counts_source")
 def fixture_number_counts_source() -> nc.NumberCounts:
-    pzshift = nc_sys.PhotoZShift(sacc_tracer="lens0")
-    magnification = nc_sys.ConstantMagnificationBiasSystematic(sacc_tracer="lens0")
-    nl_bias = nc_sys.PTNonLinearBiasSystematic(sacc_tracer="lens0")
+    pzshift = nc.PhotoZShift(sacc_tracer="lens0")
+    magnification = nc.ConstantMagnificationBiasSystematic(sacc_tracer="lens0")
+    nl_bias = nc.PTNonLinearBiasSystematic(sacc_tracer="lens0")
     return nc.NumberCounts(
         sacc_tracer="lens0", has_rsd=True, systematics=[pzshift, magnification, nl_bias]
     )
@@ -261,7 +256,7 @@ def test_pt_mixed_systematics(sacc_data):
     ia_systematic = wl.TattAlignmentSystematic(include_z_dependence=True)
     wl_source = wl.WeakLensing(sacc_tracer="src0", systematics=[ia_systematic])
 
-    magnification = nc_sys.ConstantMagnificationBiasSystematic(sacc_tracer="lens0")
+    magnification = nc.ConstantMagnificationBiasSystematic(sacc_tracer="lens0")
     nc_source = nc.NumberCounts(
         sacc_tracer="lens0", has_rsd=True, systematics=[magnification]
     )
@@ -393,7 +388,7 @@ def test_pt_mixed_systematics_zdep(sacc_data):
     ia_systematic = wl.TattAlignmentSystematic(include_z_dependence=True)
     wl_source = wl.WeakLensing(sacc_tracer="src0", systematics=[ia_systematic])
 
-    magnification = nc_sys.ConstantMagnificationBiasSystematic(sacc_tracer="lens0")
+    magnification = nc.ConstantMagnificationBiasSystematic(sacc_tracer="lens0")
     nc_source = nc.NumberCounts(
         sacc_tracer="lens0", has_rsd=True, systematics=[magnification]
     )
@@ -729,8 +724,8 @@ def test_pt_systematics_zdep(weak_lensing_source, number_counts_source, sacc_dat
 
 
 def test_linear_bias_systematic(tools_with_vanilla_cosmology: ModelingTools):
-    a = nc_sys.LinearBiasSystematic("xxx")
-    assert isinstance(a, nc_sys.LinearBiasSystematic)
+    a = nc.LinearBiasSystematic("xxx")
+    assert isinstance(a, nc.LinearBiasSystematic)
     assert a.parameter_prefix == "xxx"
     assert a.alphag is None
     assert a.alphaz is None
@@ -742,7 +737,7 @@ def test_linear_bias_systematic(tools_with_vanilla_cosmology: ModelingTools):
     assert a.alphaz == 2.0
     assert a.z_piv == 1.5
 
-    orig_nca = nc_args.NumberCountsArgs(
+    orig_nca = nc.NumberCountsArgs(
         z=np.array([0.5, 1.0]),
         dndz=np.array([5.0, 4.0]),
         bias=np.array([1.0, 1.0]),


### PR DESCRIPTION
## Description

Export private symbols through public API and pin sacc version

This PR expands the public API surface of firecrown by re-exporting symbols that were previously only accessible through private (underscore-prefixed) modules. It also pins the sacc dependency to < 2.2 to avoid incompatibilities.

External code and tests were importing directly from private modules (e.g., firecrown.likelihood._base, firecrown.metadata_types._compatibility, firecrown.likelihood.number_counts._factories). These imports are fragile because private modules are not part of the public API contract and may be renamed, reorganized, or removed without notice. This PR makes the necessary symbols available through their package-level __init__.py files, allowing all consumers to use stable public import paths.

### Public API expansion

Symbols previously accessible only through private modules are now re-exported from their package `__init__.py`:

| Package | New exports |
|---|---|
| `firecrown.likelihood` | `PhotoZShiftFactory`, `PhotoZShiftandStretchFactory`, `SourceGalaxy`, `SourceGalaxyPhotoZShift`, `SourceGalaxyPhotoZShiftandStretch`, `SourceGalaxySelectField`, `dndz_shift_and_stretch_active`, `dndz_shift_and_stretch_passive`, `use_source_factory`, `use_source_factory_metadata_index`, `CMBConvergenceFactory` |
| `firecrown.likelihood.factories` | `use_source_factory`, `use_source_factory_metadata_index`, `NumberCountsFactory` |
| `firecrown.likelihood.number_counts` | `NumberCountsArgs`, `ConstantMagnificationBiasSystematicFactory`, `LinearBiasSystematicFactory`, `MagnificationBiasSystematicFactory`, `NumberCountsSystematicFactory`, `PTNonLinearBiasSystematicFactory`, `LinearBiasSystematic`, `NumberCountsSystematic`, `PhotoZShiftandStretch` |
| `firecrown.likelihood.weak_lensing` | `WeakLensingSystematicFactory` |
| `firecrown.metadata_types` | `measurement_is_compatible_harmonic`, `measurement_is_compatible_real`, `measurement_supports_harmonic`, `measurement_supports_real` |
| `firecrown.app.sacc` | `mean_std_tracer` |

### Symbol renaming

- `_measurement_supports_real` → `measurement_supports_real`
- `_measurement_supports_harmonic` → `measurement_supports_harmonic`

These functions in `firecrown/metadata_types/_compatibility.py` had their leading underscores removed, making them public symbols. All internal call sites were updated accordingly.


## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Bug fix (non-breaking change which fixes an issue)

## Checklist

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

* [x] I have run `make pre-commit` and fixed any issues
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have made corresponding changes to the documentation
* [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
