### PR TITLE
Use sacc 2.3

### DIFF
--- a/.github/conda-lock/py3.11.conda-lock.yml
+++ b/.github/conda-lock/py3.11.conda-lock.yml
@@ -13,8 +13,8 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 5f7f05a7f6c727bd3dd22c8b6583fb6e2cc761c6d2c9503b08c88800c7a88814
-    osx-arm64: 01f8571b77ef3cd126307b9491ebbd4f3423d7b06f2530aed517d489e37d40f3
+    linux-64: 97f249646f65affc933fd097807736c4365b0abacb522125711104c87fd85229
+    osx-arm64: e5ebb707419e83ef8af564295bdc02311639969654f770ee0cdc425cf85973b6
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -178,7 +178,7 @@ package:
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -186,14 +186,14 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -201,10 +201,10 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: appnope
@@ -336,7 +336,7 @@ package:
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -345,14 +345,14 @@ package:
     cpython: '>=3.10'
     libgcc: '>=14'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.5.0-py310hd8a072f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.6.0-py310hd8a072f_0.conda
   hash:
-    md5: 6adea4814147f458d6278d053850b0ac
-    sha256: cf1cf3d0fa59fe0ab6bc3af722d820c1a85a9233c786f614f377c651fec6a7f9
+    md5: 530aaeffb462b062bf8e3abb66879cf0
+    sha256: 98eef90c96e2185254d12e667337077b989e9892167ff2c969e19b9296f42743
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -360,10 +360,10 @@ package:
     _python_abi3_support: 1.*
     cpython: '>=3.10'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.5.0-py310h3b8a9b8_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.6.0-py310h3b8a9b8_0.conda
   hash:
-    md5: 480f5277fd3ed13ea6ea8b5d74563815
-    sha256: 6c6e47ef2a85e7ade5c94d2388f43bd8197129e6b6305f9e8a49380b7dfbc427
+    md5: 9bc9209a773faadbdca5fe45d9aa9cdc
+    sha256: 0efbe4158ee4d5ff4108ad1b8c677e85eb1a8f3bb48fe2277579860d38e48315
   category: main
   optional: false
 - name: astroid
@@ -393,66 +393,66 @@ package:
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
     libgcc: '>=14'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-7.2.0-py311h0372a8f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-8.0.0-py311h0372a8f_0.conda
   hash:
-    md5: b35fbd6a1acec70c7833f0ec85439797
-    sha256: a001ba23cf670d94b3bda8f34f594df6cfdb5a7fca5db57306cf4f59ecdcf9f0
+    md5: 0092cb42e430bcf6cd2f8b9701144316
+    sha256: 992294533e6f8b18d978b1dbe5a39a8c55992ea248a64ef145a080693bb8ff31
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-7.2.0-py311h09efe57_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-8.0.0-py311h48bb571_0.conda
   hash:
-    md5: b478b72796c546e366bad76f5db64fdd
-    sha256: 58ec7d88933dacb6d06a3c22536e1316d4a597f66008782431bb3b34c876e434
+    md5: 831234836f0def2d5dbfc8fe6791df09
+    sha256: ea4f8a57278bcfa4025509de0bd4556e8e8a79f5e20bae910c212da9342d2e14
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: asttokens
@@ -601,12 +601,12 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
   hash:
-    md5: c463d2dbfb12a208c943165d2a568db4
-    sha256: 5b9c20a38fe084b4ffd1f2c64b3797ec6ef9a99e83cc0c1f84e016c9801e3a5c
+    md5: 9329dcd00c4d61aa49e516dddd784e91
+    sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
   category: main
   optional: false
 - name: aws-c-auth
@@ -619,11 +619,11 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
   hash:
-    md5: e7501df14d3145fc86943ebfeb76a402
-    sha256: b4689664156e8067ba1aa97125f2a309a96b2bc0d1c608f4a88f30ea1f4c9aba
+    md5: 1fc365a60432d78b729d1468fce1b6c9
+    sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
   category: main
   optional: false
 - name: aws-c-cal
@@ -748,11 +748,11 @@ package:
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-    s2n: '>=1.7.3,<1.7.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h5b668fc_4.conda
+    s2n: '>=1.7.4,<1.7.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
   hash:
-    md5: 555400dce62f2d989ff77761c010d166
-    sha256: c27b972325342f062da00b7aa2d5abf6f3ce55668a05703a175be958745cc226
+    md5: 12697e83c2a0e5b93fd03855a70eb360
+    sha256: c798005b65bc74d02aba1db01d4d344c4e72662f0beef35fbdd35b4695c197de
   category: main
   optional: false
 - name: aws-c-io
@@ -763,14 +763,14 @@ package:
     __osx: '>=11.0'
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
   hash:
-    md5: b33f51eca94f6ccbd772ca4043fe1718
-    sha256: 18f51bdc45eabe01ca68edf5ccc73369b3201639790575e6776f3efaea6e4356
+    md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
+    sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -782,15 +782,15 @@ package:
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
   hash:
-    md5: 70bc8e5e8cefd19407423733e7ebf540
-    sha256: 8f193173f1dccb25ff86a95543db27f0c762cccfe93157b02cf20bd5b4c11a92
+    md5: f2b6275244daa12109bcd0a126f1fb85
+    sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -801,37 +801,37 @@ package:
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
   hash:
-    md5: 7dc63973f9fe772985b8c2f8ba5958ce
-    sha256: 0a99b506bbe21f00f21047db50b2eea2ff8a0b1146ff0fba7d04b39a568453f4
+    md5: 912c61c44a2782693d63af2272551455
+    sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
   hash:
-    md5: 4b66ac29a7e917a629b790c3d239d110
-    sha256: 123c4325b16f1f6db95846d51e5e4201399ee29c0325f8b5a8db2e7d732b9151
+    md5: 5088795f3dfcf00a26f03c2a17ae8429
+    sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
   hash:
-    md5: 127bce41f9e6cc3bdb9e6daed95896d9
-    sha256: ef53cd1e30bc8c865c44df6f097f36361945665157e63957d68fe90aa7e4d66c
+    md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
+    sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
   category: main
   optional: false
 - name: aws-checksums
@@ -886,7 +886,7 @@ package:
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -895,14 +895,14 @@ package:
     python: ''
     python_abi: 3.11.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py311h6b1f9c4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.6.0-py311h6b1f9c4_0.conda
   hash:
-    md5: 624e015a6784f7b1b8c0071a557e7791
-    sha256: 79fd407b109c359182fcdd4efef15e122622941690648daacc2d24647f2593b1
+    md5: 434f289a3aea1a1f5ace0f2226a53fe6
+    sha256: bb42ea7eee74a6ade6be8ad94239f2dcc54d5939577a3488ee25a5f534bf0d4c
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -910,10 +910,10 @@ package:
     python: ''
     python_abi: 3.11.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.5.0-py311h36d4fbb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.6.0-py311h36d4fbb_0.conda
   hash:
-    md5: c2e8c0ad87a6e657908fd75e45b7f8eb
-    sha256: 45a281be7df77eb858a5355f6437b46db04add6908a7cbcb4dca5e5c5f16d29b
+    md5: ab2cfcf1499efba573df019a9aa1f3dc
+    sha256: 51b1b6c4c7c0b77bc8f145f4dd6d9fcb97ee5bd999cc125a0650ebc632107fbe
   category: main
   optional: false
 - name: beautifulsoup4
@@ -1247,7 +1247,7 @@ package:
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -1257,14 +1257,14 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.3-hc31b594_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.5-hc31b594_0.conda
   hash:
-    md5: 2f0eb57a686a4e27719ce0b0076784a1
-    sha256: 4029fb93e133c0de986464c2f1b02630f141f976cb25b5b929994b34a2a51bf5
+    md5: 76ea4a0e8f1600f89cbb2d3d62ac2b04
+    sha256: 6e42591b70252b4e91a3391894c570e45d7f1f21b20937c8f57f16e3cf659e5d
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1273,10 +1273,10 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.3-hf9886e1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.5-hf9886e1_0.conda
   hash:
-    md5: 8cbeea5e4377be5f486b94ee658590a9
-    sha256: 828449a87f57b4ccb793f1db645cf9d5a816186d978de6df31b053a57b248204
+    md5: c70b84faedf42fe923b584a587159081
+    sha256: a2db3ad1b7fedc40b3436d5382415bb63faac2baf69142c369f6040b71aeb8be
   category: main
   optional: false
 - name: c-compiler
@@ -1309,27 +1309,27 @@ package:
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: cached-property
@@ -1524,27 +1524,27 @@ package:
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: cffi
@@ -2090,7 +2090,7 @@ package:
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -2099,14 +2099,14 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.1-py311h3778330_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.3-py311h3778330_0.conda
   hash:
-    md5: f875c239f662e1b31fbf32282f1da087
-    sha256: ebefe7c8a41d14e4a50c5b862cf0226b3ac745495415bb6fb0db364b945cfe3a
+    md5: fd575752ccdef69e8381a26d641d04a4
+    sha256: a143654fedbc23b70b6acc2077e2b6eaf5ff05b9f311084ffe5652d39e9d2020
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2114,10 +2114,10 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.1-py311hc290fe0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.3-py311hc290fe0_0.conda
   hash:
-    md5: 2e3107762a2b8bb31093fe14bab1fe17
-    sha256: d9475f473084602003da38e373604b48b674b5fbd5939eb6f26b757cbda89f28
+    md5: 3d7e96733f48d9623ab9cef29c45e7c0
+    sha256: 27306b6a944eae0565fb7d4483b7de287f739b1e8f11363e4b259b4b54b02d32
   category: main
   optional: false
 - name: cpython
@@ -2198,7 +2198,7 @@ package:
   category: main
   optional: false
 - name: cython
-  version: 3.2.5
+  version: 3.2.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -2207,14 +2207,14 @@ package:
     libstdcxx: '>=14'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.5-py311h0daaf2c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.8-py311h0daaf2c_0.conda
   hash:
-    md5: 285d32d8160e800cb853a2ac0f64d970
-    sha256: 2b5194ade96aad8ed3e35ca03e4b6455e61ab43de294040bd200f4647fa9fe47
+    md5: e03de20db0514e0279e0c133118b7766
+    sha256: e628e33fe08f9e30d8cecf2143712088a7667d8a360516b64c73cd7df843fde9
   category: main
   optional: false
 - name: cython
-  version: 3.2.5
+  version: 3.2.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2222,32 +2222,32 @@ package:
     libcxx: '>=19'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.5-py311h8ccca7f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.8-py311hf7a0982_0.conda
   hash:
-    md5: 0cec947472f46cfc194d2447c677cbb0
-    sha256: cb1ead7e938903e29c3a4cb85717effe86f91d399942d0372e31582a44df7fbc
+    md5: 59325097f58772448d01651f9c6cb82d
+    sha256: c9c41ffe18652d167fba5e0ea1663907d0049e3ffa1ec0d7cbcfc6e337ad2cd9
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.100.0-hfc2019e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.101.0-hfc2019e_0.conda
   hash:
-    md5: 97b46522187a0064a52207a3ca68621c
-    sha256: 43146af49e6911c7bc57eedfdb945cb3ecbaa73e9565e84099229345edebe0c5
+    md5: 3c5956f8de352968510d857a1dfdf929
+    sha256: 624d4599a0b72315473a8854a4abbafc4e2a774b2bd8e64788823a798546321c
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.100.0-h820172f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.101.0-h820172f_0.conda
   hash:
-    md5: 2ae10fcbebb03cae94eefc1ec6311956
-    sha256: c4595381f35451b995af233fd4fe40aa4e56497d8d5d4110250f71df0e71003a
+    md5: 0271842f65ca34de8326cf8dbd38dda8
+    sha256: cafab0396ee8c6e24c0401d71be1669852a03e11cf130cf394b65382fe88ae7f
   category: main
   optional: false
 - name: dbus
@@ -2655,25 +2655,25 @@ package:
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.0-hfc2019e_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.1-hfc2019e_0.conda
   hash:
-    md5: 436dd09d9b9e59414bf803453795c5b5
-    sha256: e06f972eee640fe5ece7931e97bf9d317589fa9798ad19fa5c8761a7e393ace7
+    md5: 65b5461adebff76dc54e02c5c19a20a8
+    sha256: 2ff0603150014c840474d0ddc8813569d91f9ab20e83cb49b1019eb4155c0a63
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.0-hf76c51c_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.1-hf76c51c_0.conda
   hash:
-    md5: 8d9633a86fd47d9244f14f98f1d5c094
-    sha256: 73a69d92e36d9f6889ed080fc1e3cbe3ac94c9e5d6b3683c1792acf0fd86f043
+    md5: 7023b247571c6428ac7752c87193d68d
+    sha256: 340c65b3acdbe58b815b363304f93a25dd5cfd96bc0479b24f3d656b71522853
   category: main
   optional: false
 - name: exceptiongroup
@@ -3380,46 +3380,46 @@ package:
     binutils_linux-64: ''
     gcc_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
   hash:
-    md5: c75730101e8fcefeb3867aa52954bf76
-    sha256: 1a1736aaa63271c782cbe79353560f272cc889447bcab6000201e924eb9a6a27
+    md5: 90369fa27fae2f7bf7eaaccc34c793e2
+    sha256: d7f427d6db94a5eed2a43b186f8dc17cc1fbeb03517442390a36f1cde02548b0
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libglib: '>=2.88.2,<3.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.7-h2b0a6b4_0.conda
   hash:
-    md5: 7892f39a39ed39591a89a28eba03e987
-    sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
+    md5: 5d355db3e937086e22cf4cb5fe19787c
+    sha256: 1c22e37f9d7e06e9e0582ee5a55c2ddd19ea75f71f44eb13b56f504ef5c37aa5
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.2,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.6-h4e57454_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.7-h4e57454_0.conda
   hash:
-    md5: e67ebd2f639f46e52af8531622fa6051
-    sha256: 07cbba4e12430de35ea608eb3006cf1f7f63832c4f89a081cd6f3872944c1aa6
+    md5: f717a22e13a1499c9552ffff02d22d64
+    sha256: 69bb2e62a93f6407c9e9ccd4d21fe4d4e5373d64eecd6c5df318144ca4c80953
   category: main
   optional: false
 - name: getdist
@@ -3560,10 +3560,10 @@ package:
     gcc_linux-64: ==14.3.0
     gfortran_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-hd59e7da_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-h5ce6d8a_27.conda
   hash:
-    md5: 2ff2d83810d91869f20abb7e28c4d7da
-    sha256: 2e140d31ecbc74c44ab03e3fd40f51af2a0861ad399526205801bc0cd3ff5061
+    md5: cedd6fb9fad7611ee0bcb0fb531d77f1
+    sha256: b8e6bd99f0b7a5e8757a1cf9bf64edc6217206d8872fb9af5d8204e5b581b3d1
   category: main
   optional: false
 - name: gfortran_osx-arm64
@@ -3626,65 +3626,65 @@ package:
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.1-hd810c12_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.2-hbe0478d_0.conda
   hash:
-    md5: 9add1716591862a115c885dda4fcbeb5
-    sha256: 6a97b61cfb30a85c2f4a95f1f7525a873eea0b540f9f11b9cf31ad70d6635fce
+    md5: 7ac6295be13fafd7f20869b30b47ec2f
+    sha256: 84448dc33e66a2c74c58fb2a95d9e84547bc65cf44dcebf447b8d236c0ccc68b
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
     libintl-devel: ''
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.1-h92d5a4f_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.2-h2792883_0.conda
   hash:
-    md5: 937bab93d8e05d664f45f1aed40291ba
-    sha256: e6804164a3d771d369d97fd08a2db739321d452c9ffa6803f9bbf309aa1f4dfe
+    md5: a53abd3898d5addc45f164e8c5dbef50
+    sha256: 74b4c85756d2584abf3972035a3d68edd5b723527460a261b6df21bfe6980f7e
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libffi: ''
     libgcc: '>=14'
-    libglib: ==2.88.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda
+    libglib: ==2.88.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.2-h8094192_0.conda
   hash:
-    md5: e5a459d2bb98edb88de5a44bfad66b9d
-    sha256: ae41fd5c867bc4e713a8cc1dc06f5b418026fec116cc222abe33e94235c6b241
+    md5: cfe66c21ae651b84a3d25a1dbb641a54
+    sha256: 079757e4e0497d67505b52062668e4cc0d2a86ec065ae2c0c57487a178206061
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libffi: ''
-    libglib: ==2.88.1
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.1-h37541a8_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.2-h246a70f_0.conda
   hash:
-    md5: 8d4580a91948a6c3383a7c2fbfe5311c
-    sha256: 414bdf86a8096d5706293d163359def2e61b8ffd3fe106bbf2028d79e58e6a97
+    md5: 973a5ef252899cd0916418c75a864169
+    sha256: 6a98eabd4d5bb902c391e9f7c9e655ce61292ff6f1bb0c592da42fd66e6c89f9
   category: main
   optional: false
 - name: gmp
@@ -4032,10 +4032,10 @@ package:
     gcc_linux-64: ==14.3.0
     gxx_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h175a97f_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
   hash:
-    md5: 1bfdaeeea0b3d0031d9ad755296afbce
-    sha256: 89d8a3268bafb3f80e95ab9a4a062f332b11be836789cebd9ec490ccf3eb7428
+    md5: 41fae38a424bbc78438cfec6a4fde187
+    sha256: cf5a44d14732b79e3c2bc6ebe1dba4f6b9077939f3093c75e36ad340737b5c15
   category: main
   optional: false
 - name: h11
@@ -4132,21 +4132,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libglib: '>=2.88.1,<3.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
   hash:
-    md5: 21ee4640b7c2d94e584349fa12b29b9a
-    sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
+    md5: 72e956a71241633d8c80aa198fd08784
+    sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
   category: main
   optional: false
 - name: harfbuzz
@@ -4154,20 +4144,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libcxx: '>=19'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libglib: '>=2.88.1,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-hce30654_1.conda
   hash:
-    md5: 389b1c7cb4738fa74f8a142336807a13
-    sha256: 5593f4aad6580707eb268e8dbb4c562a736d87bea03f5e1551becaebfe1a6620
+    md5: 95896299aa1012c7410629b2ee360f87
+    sha256: 8922ec1cd17f558ca38c513d4880b7fadbfa08b38a563880c8c2ceddfcc1fba2
   category: main
   optional: false
 - name: hdf5
@@ -4180,8 +4161,8 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
@@ -4189,11 +4170,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
   hash:
-    md5: b1b444bca8da3ff6cc4afad1fa7f7d61
-    sha256: ff8336394dcfaccf49e56d1dd66091cf767df0d3d33f3fa440c980e0445b34cc
+    md5: 3c126667b98ad8ccf390a91b9097f574
+    sha256: 8225145aababbef3f8900b651cfa4ac9257cd4d522957711f469f6ea5b504761
   category: main
   optional: false
 - name: hdf5
@@ -4206,19 +4187,19 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
   hash:
-    md5: fb804a23360d2b40c4f9d15a8bf0b869
-    sha256: 67e9ef0dfd22a37ff51d0b19aa35e9f7da21739a624976bcac1f72ab1698e8f8
+    md5: 5cc8ba7775f6694349b7a71837bbad90
+    sha256: 8f37c0185801b81a50e4e1430501ddd1c9bfe5e6a5e4ea3c61464e0f1d9199aa
   category: main
   optional: false
 - name: healpy
@@ -4291,27 +4272,27 @@ package:
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: httpcore
@@ -4405,7 +4386,7 @@ package:
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -4415,14 +4396,14 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4432,10 +4413,10 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: icu
@@ -4465,27 +4446,27 @@ package:
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: imagesize
@@ -4536,32 +4517,6 @@ package:
   hash:
     md5: ffc17e785d64e12fc311af9184221839
     sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
   category: main
   optional: false
 - name: iniconfig
@@ -4640,7 +4595,7 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4657,14 +4612,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4681,10 +4636,10 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython_pygments_lexers
@@ -4812,29 +4767,29 @@ package:
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jinja2
@@ -4890,27 +4845,27 @@ package:
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: jsonpointer
@@ -5071,6 +5026,36 @@ package:
   hash:
     md5: 9453512288d20847de4356327d0e1282
     sha256: b538e15067d05768d1c0532a6d9b0625922a1cce751dd6a2af04f7233a1a70e9
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
   category: main
   optional: false
 - name: jupyter-lsp
@@ -5248,7 +5233,7 @@ package:
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5271,14 +5256,14 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5301,10 +5286,10 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server_terminals
@@ -5334,7 +5319,7 @@ package:
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -5342,25 +5327,25 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5368,21 +5353,21 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab_pygments
@@ -5538,11 +5523,11 @@ package:
     libedit: '>=3.1.20250104,<4.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
   hash:
-    md5: fb53fb07ce46a575c5d004bbc96032c2
-    sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
   category: main
   optional: false
 - name: krb5
@@ -5553,11 +5538,11 @@ package:
     __osx: '>=11.0'
     libcxx: '>=19'
     libedit: '>=3.1.20250104,<4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
   hash:
-    md5: e446e1822f4da8e5080a9de93474184d
-    sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+    md5: 8780f41b013d19219faef9c82260744b
+    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
   category: main
   optional: false
 - name: lark
@@ -5913,7 +5898,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5921,44 +5906,46 @@ package:
     krb5: '>=1.22.2,<1.23.0a0'
     libgcc: '>=14'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
   hash:
-    md5: c3cc2864f82a944bc90a7beb4d3b0e88
-    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+    md5: f9c59d277a16ec8f272b2d5dd2ec3335
+    sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     krb5: '>=1.22.2,<1.23.0a0'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h1359186_2.conda
   hash:
-    md5: 2f57b7d0c6adda88957586b7afd78438
-    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+    md5: dfe89fb0539ad4611998a5c6905692ff
+    sha256: b21aec36796a7d9b3c8b634f2d466c1d0a2658b2e57aa4686285cf4c10d5c227
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
   hash:
-    md5: 0325fbe13eb6dd39234eb305ac1b3cb8
-    sha256: cceb668dc1b71f054b1036dd83eca2e02c0c3a4b2ba3ad28c74a982d819597a3
+    md5: 89f76a2a21a3ec3ec983b5eb237c4113
+    sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
   category: main
   optional: false
 - name: libcxx-devel
@@ -6129,31 +6116,31 @@ package:
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
   hash:
-    md5: 0b82ff1ab3db9122f20cafe93f61bc3b
-    sha256: c2b53beed03c735b18116d5227410b15cc9fbef209795212afd179f8c8a5fd70
+    md5: b04e60c49d09399a009f3bb70bb53a23
+    sha256: 45bb0eb92000a3f82555cc948013935aace8a1ea522b79700f58d3906c18e846
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.5.1-hce30654_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
   hash:
-    md5: fbd3f6f592ca4d3c404c303c1c5d89bd
-    sha256: e792acfdeb39c508640f5558ef79d190c88c589edc1e00605a44159af0cadf34
+    md5: b92a04dd36f41b0d8dfed62ff7812eea
+    sha256: 048eb6e03202b5a6f8ecbcdeb5a3f5ac9702736aa494de6615639d60ff68adc9
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -6161,22 +6148,22 @@ package:
     libgcc: '>=14'
     libnl: '>=3.11.0,<4.0a0'
     rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
   hash:
-    md5: 4a7168d686b6125ba546134dddb16721
-    sha256: f64b69e48636871081fde0604ed37fac32a7146073ad2899550bcc0b14e7c09d
+    md5: 7d8c510157360d0a6fdd84a1d3db8de7
+    sha256: ba8de6a838bc0727ef8e5a1409c6735465b7b582627a9b4c2704126e53903f43
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.5.1-h84a0fba_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
   hash:
-    md5: 7e0759abab6964339520b84d0990c07a
-    sha256: 071a14074dbf7f7be2fb52798638e9a8194324bcb8deab50b452cc099729ea1c
+    md5: 5b0d1d64a7fe7e86900dd1859d2dd4d4
+    sha256: 267ab5fe990209b33de220432bcb595a88e6bb642e282bbe433a8edfdc811c1a
   category: main
   optional: false
 - name: libffi
@@ -6530,7 +6517,7 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -6540,14 +6527,14 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
   hash:
-    md5: 17d484ab9c8179c6a6e5b7dbb5065afc
-    sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
+    md5: 889febc66cd9e4190f80ef9718fa239b
+    sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6557,10 +6544,10 @@ package:
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.2-ha08bb59_0.conda
   hash:
-    md5: 62d6f3b832d7d79ae0c0aa1bb3c325fa
-    sha256: 3b32a7a710132d509f2ea38b2f0384414c863533e0fc7ac71b6a0763e4c67424
+    md5: 03123cafdc96cef79fc8a615f9119b79
+    sha256: 68ac66904a284a7dfbb3bdf9225380eaf20750b2d414215e6d7af5caa3ed1a63
   category: main
   optional: false
 - name: libglvnd
@@ -6614,6 +6601,96 @@ package:
   hash:
     md5: faac990cb7aedc7f3a2224f2c9b0c26c
     sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+  hash:
+    md5: fb4669c3990b94ea32fbb81f433e9aa6
+    sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e8d6e86663316dfbdec7dac532824516
+    sha256: 75860db66af9748572038d1e3a2260eca56ee4b38b9523e042fac8caf4277529
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+  hash:
+    md5: 99cf21100441e51272f1cd6fe0632a20
+    sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-devel-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e538f961a3042abf8307c5c5a6d6b09b
+    sha256: f3f74f090b6a31fed00d64cbe6bbeed6b2a9b820442714ecb66ada08dec913ea
   category: main
   optional: false
 - name: libhwloc
@@ -6921,6 +6998,68 @@ package:
     sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   category: main
   optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hd9031aa_0.conda
+  hash:
+    md5: e2834a423b3967e7b3b1e901c4a5f42f
+    sha256: cd11890a2c1f14d0342bfcbd81f97152d61dc71c27c7085efc13705a8f64f7c9
+  category: main
+  optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-hb427e8f_0.conda
+  hash:
+    md5: 39234f5550649043b04b3d73a2017f81
+    sha256: c14b5b584dc349df5ff5f6fa114d522090a0488fcb1599df0881fd53af45010c
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.10.5-h6406941_1.conda
+  hash:
+    md5: fa63517815747363c41b439ff9301db1
+    sha256: 7c9e562842f193f772ef0ba681f238a2d9e5ef637588b6e46eb30cc6aa1940c8
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libraqm-0.10.5-h45af499_1.conda
+  hash:
+    md5: fa1a27aaaa10e92be48372fa01573f7c
+    sha256: 7d88c506b9899d60e57f7456b02f54c7330029f2ad56c6df96357f981aa1bd96
+  category: main
+  optional: false
 - name: librsvg
   version: 2.62.3
   manager: conda
@@ -7015,31 +7154,30 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
   hash:
-    md5: 062b0ac602fb0adf250e3dfa86f221c4
-    sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+    md5: 4aed8e657e9ff156bdbe849b4df44389
+    sha256: 365376f4815e5e80def2b3462a2419708b7c292da0da85278386c2618621fff4
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.3-h1b79a29_0.conda
   hash:
-    md5: 1ebde5c677f00765233a17e278571177
-    sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+    md5: 7184d95871a58b8258a8ea124ed5aabc
+    sha256: a73a8acd97a6599fd6e561514db9f101ca7fd984cdc0cfd91ba74c8aa9dbe067
   category: main
   optional: false
 - name: libssh2
@@ -7177,16 +7315,16 @@ package:
   category: main
   optional: false
 - name: libuuid
-  version: 2.42.1
+  version: 2.42.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
   hash:
-    md5: 7d0a66598195ef00b6efc55aefc7453b
-    sha256: 3f0edf1280e2f6684a986f821eaa3e123d2694a00b31b96ca0d4a4c12c129231
+    md5: 01bb81d12c957de066ea7362007df642
+    sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
   category: main
   optional: false
 - name: libwebp-base
@@ -7399,15 +7537,15 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.7-hc7d1edf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
   hash:
-    md5: 7c6a5897a8bc5b6d509a4ee9dec7fcc8
-    sha256: 6bf27376f11198c01a88a1c8234470f45bce0aa7502b7e7988ef03ef5db3a890
+    md5: a9c118f6343fb6301b6f3b4e94c4c562
+    sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
   category: main
   optional: false
 - name: llvm-tools
@@ -7580,7 +7718,7 @@ package:
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7593,6 +7731,7 @@ package:
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
+    libraqm: '>=0.10.5,<0.11.0a0'
     libstdcxx: '>=14'
     numpy: '>=1.23,<3'
     packaging: '>=20.0'
@@ -7603,14 +7742,14 @@ package:
     python_abi: 3.11.*
     qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py311h0f3be63_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py311h0a88c4d_1.conda
   hash:
-    md5: cc259645be458c9222ffcf321ff5fc1e
-    sha256: 3e122e4aacab6f07e046d87ddd2ad5896fb3bf344748ca784be3274891a4db8d
+    md5: 52b7cff4886e5276e7d71e5356025d99
+    sha256: 95b1c40de67700e56fc48325272c01c111a196f37995bd75825bcd5e14c94e03
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7623,6 +7762,7 @@ package:
     libcxx: '>=19'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
+    libraqm: '>=0.10.5,<0.11.0a0'
     numpy: '>=1.23,<3'
     packaging: '>=20.0'
     pillow: '>=8'
@@ -7631,10 +7771,10 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.11.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py311h68bafec_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.0-py311h00527d9_1.conda
   hash:
-    md5: bbf824cfa16d55856fb12f04026030c6
-    sha256: 5d005eec8908fd10a6a2cf9aa157e96b4544b8705ba4136339c7bc750296d40d
+    md5: 1dcfd30f3550680d19484b0b500b10f0
+    sha256: ac5038e313857da5cd4c7190db6b5288a0fe09c2452260a2102a316008af980c
   category: main
   optional: false
 - name: matplotlib-inline
@@ -7763,29 +7903,29 @@ package:
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mizani
@@ -8109,27 +8249,27 @@ package:
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: nautilus-sampler
@@ -8376,39 +8516,39 @@ package:
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook-shim
@@ -9042,16 +9182,16 @@ package:
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9060,22 +9200,22 @@ package:
     python_abi: 3.11.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py311hf88fc01_0.conda
   hash:
-    md5: b4e4b0fc807b68aa1706457f2e31279d
-    sha256: 5b182a7588874e497514b52e2ef278b66fa4089e94379d249897df28b917a659
+    md5: 9782d37ef50862d2c8a9ba58c1725754
+    sha256: fc8a6dbcf1f367cc33ae6d505370b8d9d51ca5eae9b53bf1517307f863300d27
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9084,10 +9224,10 @@ package:
     python_abi: 3.11.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py311hd37aea2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.3.0-py311hd37aea2_0.conda
   hash:
-    md5: 9b5458ae3fbc4fa5c3e427ff81e037cb
-    sha256: b283397037294e56d3720ddd78489dd43d959eaf6453d51cb68d97bb0a52585f
+    md5: 26ba3b773222fada6f89baf4846190e3
+    sha256: 3c680e002d0aadf9e21b6ee50929d8fec6ced9234b1340a027255b4518e6e49f
   category: main
   optional: false
 - name: pip
@@ -9197,7 +9337,7 @@ package:
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -9208,14 +9348,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9226,10 +9366,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: pluggy
@@ -9944,7 +10084,7 @@ package:
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -9957,14 +10097,14 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9977,10 +10117,10 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pyobjc-core
@@ -10117,11 +10257,11 @@ package:
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10129,18 +10269,18 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10148,10 +10288,10 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest-cov
@@ -10446,7 +10586,7 @@ package:
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10454,24 +10594,24 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.11.0-py311haee01d2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.12.0-py311haee01d2_0.conda
   hash:
-    md5: 5211fbc1a437503e8df1f8bcadd86651
-    sha256: be4672e9a1c5c052529767b3675f766e10cca5ef207c76ddb21a8927f84fe1ac
+    md5: d76df91f62503435f8434f39b52da22a
+    sha256: 5798e401f1abb4f3c8780fe83b251a078483baf4f2800306288d3c224b74bdd7
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: 3.11.*
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.11.0-py311he363849_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.12.0-py311he363849_0.conda
   hash:
-    md5: ae00b0abc1c1045b8cc1096d4fda7dba
-    sha256: e84beff7a238f389327712beb7e1b6c10d5b750da9bd99eb3ca71b2327e2e045
+    md5: 2fc4925a4fab8e77963064befd0282c4
+    sha256: 88ca3b3d59c972c64f25259d8a2a922f202f668c67078392d8fa815398506080
   category: main
   optional: false
 - name: python-tzdata
@@ -10641,7 +10781,7 @@ package:
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -10650,14 +10790,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10666,10 +10806,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: quarto
@@ -11006,7 +11146,7 @@ package:
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -11014,42 +11154,42 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.5.1-py311h1baac5b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py311h1baac5b_0.conda
   hash:
-    md5: d95df38d5ea0f1134ef39e16ed1c28e9
-    sha256: a2a40c189cf925a0c6dcffba5b02011d4be0e555ffe40d122a88a15ae328dd35
+    md5: 0311b3d56cad517ab1a80fd4f9332e3f
+    sha256: ec844a6df82774ff6790e60ddf6137cac54ee5d41fe2226f0da2bad0ab84e1ae
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: ''
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.5.1-py311haff49d3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py311haff49d3_0.conda
   hash:
-    md5: ee72a46b3af924481252a2154ee29797
-    sha256: 433b676c6de3759fe4ab89d17acb6ac7f3008f48b3d9fb1cb8fda82840676b5c
+    md5: f55ea3840a1a4c76fdb03dc8d95e7a76
+    sha256: 466a9df1864e3104ca95bb7292fb045fd320c0b40e71647162341329437eb23e
   category: main
   optional: false
 - name: s2n
-  version: 1.7.3
+  version: 1.7.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
   hash:
-    md5: f2bd09e21c5844a12e2f5eefcd075555
-    sha256: 150a0a5254e8b15ad737549721c7d13406cd96432f3f446e07073dbd98bb2491
+    md5: a20feedf58ce5441b115cebf284a9a75
+    sha256: de0bb8c7526684c9927cc687d4d07abe09d023a3ec950cfcd61089b495e2e616
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: linux-64
   dependencies:
@@ -11057,14 +11197,14 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11072,10 +11212,10 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: scikit-learn
@@ -11822,29 +11962,29 @@ package:
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: stack_data
@@ -11987,7 +12127,7 @@ package:
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -11997,15 +12137,15 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12015,11 +12155,11 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tabulate
@@ -12245,29 +12385,29 @@ package:
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: traitlets
@@ -12295,7 +12435,7 @@ package:
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -12304,14 +12444,14 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12320,10 +12460,10 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: types-pyyaml
@@ -12640,27 +12780,27 @@ package:
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: webcolors
@@ -12786,7 +12926,7 @@ package:
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12794,38 +12934,38 @@ package:
     libgcc: '>=14'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.1-py311h49ec1c0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py311h49ec1c0_0.conda
   hash:
-    md5: e6cc7808fc5ac070f75c682ca9d00cb5
-    sha256: 4461bb07b3aed91fcfb437891a53a0fa0c2591910bc5da85abce481694effced
+    md5: ebf29957ecd2619000dd136b80bf5933
+    sha256: 12dbcbf5416c05f2fae8e13839a6c811342249dfb736c91b8ebcad5370ec03c8
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.1-py311hc949640_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py311hc949640_0.conda
   hash:
-    md5: 7961f1a5c00e95c91a4e7c1ed4d7a860
-    sha256: 2541189672f4ab14af7df4e9b92adc03029c955023d5819e531790a7f423c63f
+    md5: a83b675267cb319b59a69db13755d7f5
+    sha256: e0ed3808fef0d3afcccb23a172e8257003d1a4594ccdfa08a0d084d6cae5ab4e
   category: main
   optional: false
 - name: xkeyboard-config
-  version: '2.47'
+  version: '2.48'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
   hash:
-    md5: b56e0c8432b56decafae7e78c5f29ba5
-    sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
+    md5: b233b41be0bf210989d57160ed39b394
+    sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
   category: main
   optional: false
 - name: xorg-libice

--- a/.github/conda-lock/py3.12.conda-lock.yml
+++ b/.github/conda-lock/py3.12.conda-lock.yml
@@ -13,8 +13,8 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 1f43639d88b717cc9ad13b70f383a5a5bd7f84640ee4c0d4362432210b588a82
-    osx-arm64: 9395fb6304f9f0b6fef069d7755cabbce994df0c0f6f03393874744460917321
+    linux-64: 4b0a5c7b895534ca864c64e28b7a414f102764f5843302ecc554f5a7849c230a
+    osx-arm64: b4c81558d690bec6e45b02b96363a27490e124e7885acf94b0f20f9069e4ffdc
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -178,7 +178,7 @@ package:
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -186,14 +186,14 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -201,10 +201,10 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: appnope
@@ -336,7 +336,7 @@ package:
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -345,14 +345,14 @@ package:
     cpython: '>=3.10'
     libgcc: '>=14'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.5.0-py310hd8a072f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.6.0-py310hd8a072f_0.conda
   hash:
-    md5: 6adea4814147f458d6278d053850b0ac
-    sha256: cf1cf3d0fa59fe0ab6bc3af722d820c1a85a9233c786f614f377c651fec6a7f9
+    md5: 530aaeffb462b062bf8e3abb66879cf0
+    sha256: 98eef90c96e2185254d12e667337077b989e9892167ff2c969e19b9296f42743
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -360,10 +360,10 @@ package:
     _python_abi3_support: 1.*
     cpython: '>=3.10'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.5.0-py310h3b8a9b8_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.6.0-py310h3b8a9b8_0.conda
   hash:
-    md5: 480f5277fd3ed13ea6ea8b5d74563815
-    sha256: 6c6e47ef2a85e7ade5c94d2388f43bd8197129e6b6305f9e8a49380b7dfbc427
+    md5: 9bc9209a773faadbdca5fe45d9aa9cdc
+    sha256: 0efbe4158ee4d5ff4108ad1b8c677e85eb1a8f3bb48fe2277579860d38e48315
   category: main
   optional: false
 - name: astroid
@@ -393,66 +393,66 @@ package:
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
     libgcc: '>=14'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-7.2.0-py312h4f23490_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-8.0.0-py312h4f23490_0.conda
   hash:
-    md5: a2826f4e9101450669fcfbe1b3b16820
-    sha256: e427fdcc692ac4c2c5be3d39886c5c86479ac924d07196a2375b66467d2f7ba7
+    md5: 7a7c460fa45a5cca6f248e5bf70946d9
+    sha256: 865dff428943870d795ebdd2c09c9c7d2b849513f05b14f52009af95001025bf
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-7.2.0-py312ha11c99a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-8.0.0-py312hf57c059_0.conda
   hash:
-    md5: 805e724e1d067bf930ea9a342640a402
-    sha256: 1d235639c72e2704e4a71548ae229f6fddd5a7599363027ee887692cfa2ad6af
+    md5: 92ee284fb27eee2d248e94b205f5ea99
+    sha256: 6cfd26da9d7d191732a74b41ca132a31082235d774dc72f6a135fac8e9068953
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: asttokens
@@ -601,12 +601,12 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
   hash:
-    md5: c463d2dbfb12a208c943165d2a568db4
-    sha256: 5b9c20a38fe084b4ffd1f2c64b3797ec6ef9a99e83cc0c1f84e016c9801e3a5c
+    md5: 9329dcd00c4d61aa49e516dddd784e91
+    sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
   category: main
   optional: false
 - name: aws-c-auth
@@ -619,11 +619,11 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
   hash:
-    md5: e7501df14d3145fc86943ebfeb76a402
-    sha256: b4689664156e8067ba1aa97125f2a309a96b2bc0d1c608f4a88f30ea1f4c9aba
+    md5: 1fc365a60432d78b729d1468fce1b6c9
+    sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
   category: main
   optional: false
 - name: aws-c-cal
@@ -748,11 +748,11 @@ package:
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-    s2n: '>=1.7.3,<1.7.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h5b668fc_4.conda
+    s2n: '>=1.7.4,<1.7.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
   hash:
-    md5: 555400dce62f2d989ff77761c010d166
-    sha256: c27b972325342f062da00b7aa2d5abf6f3ce55668a05703a175be958745cc226
+    md5: 12697e83c2a0e5b93fd03855a70eb360
+    sha256: c798005b65bc74d02aba1db01d4d344c4e72662f0beef35fbdd35b4695c197de
   category: main
   optional: false
 - name: aws-c-io
@@ -763,14 +763,14 @@ package:
     __osx: '>=11.0'
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
   hash:
-    md5: b33f51eca94f6ccbd772ca4043fe1718
-    sha256: 18f51bdc45eabe01ca68edf5ccc73369b3201639790575e6776f3efaea6e4356
+    md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
+    sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -782,15 +782,15 @@ package:
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
   hash:
-    md5: 70bc8e5e8cefd19407423733e7ebf540
-    sha256: 8f193173f1dccb25ff86a95543db27f0c762cccfe93157b02cf20bd5b4c11a92
+    md5: f2b6275244daa12109bcd0a126f1fb85
+    sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -801,37 +801,37 @@ package:
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
   hash:
-    md5: 7dc63973f9fe772985b8c2f8ba5958ce
-    sha256: 0a99b506bbe21f00f21047db50b2eea2ff8a0b1146ff0fba7d04b39a568453f4
+    md5: 912c61c44a2782693d63af2272551455
+    sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
   hash:
-    md5: 4b66ac29a7e917a629b790c3d239d110
-    sha256: 123c4325b16f1f6db95846d51e5e4201399ee29c0325f8b5a8db2e7d732b9151
+    md5: 5088795f3dfcf00a26f03c2a17ae8429
+    sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
   hash:
-    md5: 127bce41f9e6cc3bdb9e6daed95896d9
-    sha256: ef53cd1e30bc8c865c44df6f097f36361945665157e63957d68fe90aa7e4d66c
+    md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
+    sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
   category: main
   optional: false
 - name: aws-checksums
@@ -886,7 +886,7 @@ package:
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -895,14 +895,14 @@ package:
     python: ''
     python_abi: 3.12.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.6.0-py312h90b7ffd_0.conda
   hash:
-    md5: b31dba71fe091e7201826e57e0f7b261
-    sha256: a2b08a4e5e549b5f67c38edffd175437e2208547a7e67b5fa5373b67ef419e50
+    md5: 55811da425538da800b89c0c588652fa
+    sha256: 95b3d6d44c17c4061db703289f39915646e455f75f0c8c9d949bf081d2e61579
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -910,10 +910,10 @@ package:
     python: ''
     python_abi: 3.12.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.5.0-py312h87c4bb7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.6.0-py312h87c4bb7_0.conda
   hash:
-    md5: 6ec306e02579965dc9c01092a5f4ce4c
-    sha256: a492dcf07b1c58797b3192f11aef7e3beb18ec91646d6a5acfe5c6e61e66118d
+    md5: 4447051eb9b01fed8c9cda74ecc800cd
+    sha256: e1aad5d00ad9566a06e9ac0912efec406c6d844b6d48e0696db18f0a655323a2
   category: main
   optional: false
 - name: beautifulsoup4
@@ -1247,7 +1247,7 @@ package:
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -1257,14 +1257,14 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.3-hc31b594_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.5-hc31b594_0.conda
   hash:
-    md5: 2f0eb57a686a4e27719ce0b0076784a1
-    sha256: 4029fb93e133c0de986464c2f1b02630f141f976cb25b5b929994b34a2a51bf5
+    md5: 76ea4a0e8f1600f89cbb2d3d62ac2b04
+    sha256: 6e42591b70252b4e91a3391894c570e45d7f1f21b20937c8f57f16e3cf659e5d
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1273,10 +1273,10 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.3-hf9886e1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.5-hf9886e1_0.conda
   hash:
-    md5: 8cbeea5e4377be5f486b94ee658590a9
-    sha256: 828449a87f57b4ccb793f1db645cf9d5a816186d978de6df31b053a57b248204
+    md5: c70b84faedf42fe923b584a587159081
+    sha256: a2db3ad1b7fedc40b3436d5382415bb63faac2baf69142c369f6040b71aeb8be
   category: main
   optional: false
 - name: c-compiler
@@ -1309,27 +1309,27 @@ package:
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: cached-property
@@ -1524,27 +1524,27 @@ package:
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: cffi
@@ -2090,7 +2090,7 @@ package:
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -2099,14 +2099,14 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.1-py312h8a5da7c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.3-py312h8a5da7c_0.conda
   hash:
-    md5: 6668e2af2de730400bdce9cf2ea132f9
-    sha256: 80b990c6870c721bcde5e14e71d3560bac3dad93b54d027f723dca2bb7ccda03
+    md5: 685d6d2fac5fd5abfc581db3c94652b9
+    sha256: 15b33937f062c7c94f5978127fbcae1d3b9c30ff4dff59adab9ab2bd18365024
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2114,10 +2114,10 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.1-py312h04c11ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.3-py312h04c11ed_0.conda
   hash:
-    md5: 86b295185747ca5b09e95d7d33280382
-    sha256: 62f7590a0e6456ff8f534c3f6213e4ec50443d3409fa3babfa30a38822a2b0fa
+    md5: 87f48959c9e5ac6816f1a9d6291a15dd
+    sha256: c2d645a0f6628f67e022ef01056a2d2edeec87349d8f660b12e9de32a22d813d
   category: main
   optional: false
 - name: cpython
@@ -2198,7 +2198,7 @@ package:
   category: main
   optional: false
 - name: cython
-  version: 3.2.5
+  version: 3.2.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -2207,14 +2207,14 @@ package:
     libstdcxx: '>=14'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.5-py312h68e6be4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.8-py312h68e6be4_0.conda
   hash:
-    md5: 11654d72bf2dda3bf83dfea8784ac53d
-    sha256: d89f74179b0758dc2c314b0a3a04a7738ed1f3600529060d78eb26987c22d885
+    md5: 72177815525d6c5e684fc3ea3978b9c7
+    sha256: 66b599f2bcd23ebcf6616947ec43e9f4d8d1d4f91462ebb9545d847d8d40013e
   category: main
   optional: false
 - name: cython
-  version: 3.2.5
+  version: 3.2.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2222,32 +2222,32 @@ package:
     libcxx: '>=19'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.5-py312hedd66cf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.8-py312h72d008e_0.conda
   hash:
-    md5: 385fe173378bdc52f01ecffceee8bab6
-    sha256: 4eacb9bfd329d7ec0d18f78fe7f630a241470b341643bc35572cb84529804daa
+    md5: 1d44a15e824f89840581aa5c799f1210
+    sha256: eccd899c1cab4d3c65afbe61365fb112d19019c8915214a7ce181ef9aa1cf7b7
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.100.0-hfc2019e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.101.0-hfc2019e_0.conda
   hash:
-    md5: 97b46522187a0064a52207a3ca68621c
-    sha256: 43146af49e6911c7bc57eedfdb945cb3ecbaa73e9565e84099229345edebe0c5
+    md5: 3c5956f8de352968510d857a1dfdf929
+    sha256: 624d4599a0b72315473a8854a4abbafc4e2a774b2bd8e64788823a798546321c
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.100.0-h820172f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.101.0-h820172f_0.conda
   hash:
-    md5: 2ae10fcbebb03cae94eefc1ec6311956
-    sha256: c4595381f35451b995af233fd4fe40aa4e56497d8d5d4110250f71df0e71003a
+    md5: 0271842f65ca34de8326cf8dbd38dda8
+    sha256: cafab0396ee8c6e24c0401d71be1669852a03e11cf130cf394b65382fe88ae7f
   category: main
   optional: false
 - name: dbus
@@ -2655,25 +2655,25 @@ package:
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.0-hfc2019e_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.1-hfc2019e_0.conda
   hash:
-    md5: 436dd09d9b9e59414bf803453795c5b5
-    sha256: e06f972eee640fe5ece7931e97bf9d317589fa9798ad19fa5c8761a7e393ace7
+    md5: 65b5461adebff76dc54e02c5c19a20a8
+    sha256: 2ff0603150014c840474d0ddc8813569d91f9ab20e83cb49b1019eb4155c0a63
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.0-hf76c51c_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.1-hf76c51c_0.conda
   hash:
-    md5: 8d9633a86fd47d9244f14f98f1d5c094
-    sha256: 73a69d92e36d9f6889ed080fc1e3cbe3ac94c9e5d6b3683c1792acf0fd86f043
+    md5: 7023b247571c6428ac7752c87193d68d
+    sha256: 340c65b3acdbe58b815b363304f93a25dd5cfd96bc0479b24f3d656b71522853
   category: main
   optional: false
 - name: exceptiongroup
@@ -3382,46 +3382,46 @@ package:
     binutils_linux-64: ''
     gcc_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
   hash:
-    md5: c75730101e8fcefeb3867aa52954bf76
-    sha256: 1a1736aaa63271c782cbe79353560f272cc889447bcab6000201e924eb9a6a27
+    md5: 90369fa27fae2f7bf7eaaccc34c793e2
+    sha256: d7f427d6db94a5eed2a43b186f8dc17cc1fbeb03517442390a36f1cde02548b0
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libglib: '>=2.88.2,<3.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.7-h2b0a6b4_0.conda
   hash:
-    md5: 7892f39a39ed39591a89a28eba03e987
-    sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
+    md5: 5d355db3e937086e22cf4cb5fe19787c
+    sha256: 1c22e37f9d7e06e9e0582ee5a55c2ddd19ea75f71f44eb13b56f504ef5c37aa5
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.2,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.6-h4e57454_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.7-h4e57454_0.conda
   hash:
-    md5: e67ebd2f639f46e52af8531622fa6051
-    sha256: 07cbba4e12430de35ea608eb3006cf1f7f63832c4f89a081cd6f3872944c1aa6
+    md5: f717a22e13a1499c9552ffff02d22d64
+    sha256: 69bb2e62a93f6407c9e9ccd4d21fe4d4e5373d64eecd6c5df318144ca4c80953
   category: main
   optional: false
 - name: getdist
@@ -3562,10 +3562,10 @@ package:
     gcc_linux-64: ==14.3.0
     gfortran_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-hd59e7da_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-h5ce6d8a_27.conda
   hash:
-    md5: 2ff2d83810d91869f20abb7e28c4d7da
-    sha256: 2e140d31ecbc74c44ab03e3fd40f51af2a0861ad399526205801bc0cd3ff5061
+    md5: cedd6fb9fad7611ee0bcb0fb531d77f1
+    sha256: b8e6bd99f0b7a5e8757a1cf9bf64edc6217206d8872fb9af5d8204e5b581b3d1
   category: main
   optional: false
 - name: gfortran_osx-arm64
@@ -3628,65 +3628,65 @@ package:
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.1-hd810c12_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.2-hbe0478d_0.conda
   hash:
-    md5: 9add1716591862a115c885dda4fcbeb5
-    sha256: 6a97b61cfb30a85c2f4a95f1f7525a873eea0b540f9f11b9cf31ad70d6635fce
+    md5: 7ac6295be13fafd7f20869b30b47ec2f
+    sha256: 84448dc33e66a2c74c58fb2a95d9e84547bc65cf44dcebf447b8d236c0ccc68b
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
     libintl-devel: ''
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.1-h92d5a4f_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.2-h2792883_0.conda
   hash:
-    md5: 937bab93d8e05d664f45f1aed40291ba
-    sha256: e6804164a3d771d369d97fd08a2db739321d452c9ffa6803f9bbf309aa1f4dfe
+    md5: a53abd3898d5addc45f164e8c5dbef50
+    sha256: 74b4c85756d2584abf3972035a3d68edd5b723527460a261b6df21bfe6980f7e
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libffi: ''
     libgcc: '>=14'
-    libglib: ==2.88.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda
+    libglib: ==2.88.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.2-h8094192_0.conda
   hash:
-    md5: e5a459d2bb98edb88de5a44bfad66b9d
-    sha256: ae41fd5c867bc4e713a8cc1dc06f5b418026fec116cc222abe33e94235c6b241
+    md5: cfe66c21ae651b84a3d25a1dbb641a54
+    sha256: 079757e4e0497d67505b52062668e4cc0d2a86ec065ae2c0c57487a178206061
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libffi: ''
-    libglib: ==2.88.1
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.1-h37541a8_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.2-h246a70f_0.conda
   hash:
-    md5: 8d4580a91948a6c3383a7c2fbfe5311c
-    sha256: 414bdf86a8096d5706293d163359def2e61b8ffd3fe106bbf2028d79e58e6a97
+    md5: 973a5ef252899cd0916418c75a864169
+    sha256: 6a98eabd4d5bb902c391e9f7c9e655ce61292ff6f1bb0c592da42fd66e6c89f9
   category: main
   optional: false
 - name: gmp
@@ -4034,10 +4034,10 @@ package:
     gcc_linux-64: ==14.3.0
     gxx_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h175a97f_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
   hash:
-    md5: 1bfdaeeea0b3d0031d9ad755296afbce
-    sha256: 89d8a3268bafb3f80e95ab9a4a062f332b11be836789cebd9ec490ccf3eb7428
+    md5: 41fae38a424bbc78438cfec6a4fde187
+    sha256: cf5a44d14732b79e3c2bc6ebe1dba4f6b9077939f3093c75e36ad340737b5c15
   category: main
   optional: false
 - name: h11
@@ -4134,21 +4134,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libglib: '>=2.88.1,<3.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
   hash:
-    md5: 21ee4640b7c2d94e584349fa12b29b9a
-    sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
+    md5: 72e956a71241633d8c80aa198fd08784
+    sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
   category: main
   optional: false
 - name: harfbuzz
@@ -4156,20 +4146,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libcxx: '>=19'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libglib: '>=2.88.1,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-hce30654_1.conda
   hash:
-    md5: 389b1c7cb4738fa74f8a142336807a13
-    sha256: 5593f4aad6580707eb268e8dbb4c562a736d87bea03f5e1551becaebfe1a6620
+    md5: 95896299aa1012c7410629b2ee360f87
+    sha256: 8922ec1cd17f558ca38c513d4880b7fadbfa08b38a563880c8c2ceddfcc1fba2
   category: main
   optional: false
 - name: hdf5
@@ -4182,8 +4163,8 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
@@ -4191,11 +4172,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
   hash:
-    md5: b1b444bca8da3ff6cc4afad1fa7f7d61
-    sha256: ff8336394dcfaccf49e56d1dd66091cf767df0d3d33f3fa440c980e0445b34cc
+    md5: 3c126667b98ad8ccf390a91b9097f574
+    sha256: 8225145aababbef3f8900b651cfa4ac9257cd4d522957711f469f6ea5b504761
   category: main
   optional: false
 - name: hdf5
@@ -4208,19 +4189,19 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
   hash:
-    md5: fb804a23360d2b40c4f9d15a8bf0b869
-    sha256: 67e9ef0dfd22a37ff51d0b19aa35e9f7da21739a624976bcac1f72ab1698e8f8
+    md5: 5cc8ba7775f6694349b7a71837bbad90
+    sha256: 8f37c0185801b81a50e4e1430501ddd1c9bfe5e6a5e4ea3c61464e0f1d9199aa
   category: main
   optional: false
 - name: healpy
@@ -4293,27 +4274,27 @@ package:
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: httpcore
@@ -4407,7 +4388,7 @@ package:
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -4417,14 +4398,14 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4434,10 +4415,10 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: icu
@@ -4467,27 +4448,27 @@ package:
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: imagesize
@@ -4538,32 +4519,6 @@ package:
   hash:
     md5: ffc17e785d64e12fc311af9184221839
     sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
   category: main
   optional: false
 - name: iniconfig
@@ -4642,7 +4597,7 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4659,14 +4614,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4683,10 +4638,10 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython_pygments_lexers
@@ -4814,29 +4769,29 @@ package:
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jinja2
@@ -4892,27 +4847,27 @@ package:
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: jsonpointer
@@ -5073,6 +5028,36 @@ package:
   hash:
     md5: 9453512288d20847de4356327d0e1282
     sha256: b538e15067d05768d1c0532a6d9b0625922a1cce751dd6a2af04f7233a1a70e9
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
   category: main
   optional: false
 - name: jupyter-lsp
@@ -5250,7 +5235,7 @@ package:
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5273,14 +5258,14 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5303,10 +5288,10 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server_terminals
@@ -5336,7 +5321,7 @@ package:
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -5344,25 +5329,25 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5370,21 +5355,21 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab_pygments
@@ -5540,11 +5525,11 @@ package:
     libedit: '>=3.1.20250104,<4.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
   hash:
-    md5: fb53fb07ce46a575c5d004bbc96032c2
-    sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
   category: main
   optional: false
 - name: krb5
@@ -5555,11 +5540,11 @@ package:
     __osx: '>=11.0'
     libcxx: '>=19'
     libedit: '>=3.1.20250104,<4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
   hash:
-    md5: e446e1822f4da8e5080a9de93474184d
-    sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+    md5: 8780f41b013d19219faef9c82260744b
+    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
   category: main
   optional: false
 - name: lark
@@ -5915,7 +5900,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5923,44 +5908,46 @@ package:
     krb5: '>=1.22.2,<1.23.0a0'
     libgcc: '>=14'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
   hash:
-    md5: c3cc2864f82a944bc90a7beb4d3b0e88
-    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+    md5: f9c59d277a16ec8f272b2d5dd2ec3335
+    sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     krb5: '>=1.22.2,<1.23.0a0'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h1359186_2.conda
   hash:
-    md5: 2f57b7d0c6adda88957586b7afd78438
-    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+    md5: dfe89fb0539ad4611998a5c6905692ff
+    sha256: b21aec36796a7d9b3c8b634f2d466c1d0a2658b2e57aa4686285cf4c10d5c227
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
   hash:
-    md5: 0325fbe13eb6dd39234eb305ac1b3cb8
-    sha256: cceb668dc1b71f054b1036dd83eca2e02c0c3a4b2ba3ad28c74a982d819597a3
+    md5: 89f76a2a21a3ec3ec983b5eb237c4113
+    sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
   category: main
   optional: false
 - name: libcxx-devel
@@ -6143,31 +6130,31 @@ package:
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
   hash:
-    md5: 0b82ff1ab3db9122f20cafe93f61bc3b
-    sha256: c2b53beed03c735b18116d5227410b15cc9fbef209795212afd179f8c8a5fd70
+    md5: b04e60c49d09399a009f3bb70bb53a23
+    sha256: 45bb0eb92000a3f82555cc948013935aace8a1ea522b79700f58d3906c18e846
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.5.1-hce30654_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
   hash:
-    md5: fbd3f6f592ca4d3c404c303c1c5d89bd
-    sha256: e792acfdeb39c508640f5558ef79d190c88c589edc1e00605a44159af0cadf34
+    md5: b92a04dd36f41b0d8dfed62ff7812eea
+    sha256: 048eb6e03202b5a6f8ecbcdeb5a3f5ac9702736aa494de6615639d60ff68adc9
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -6175,22 +6162,22 @@ package:
     libgcc: '>=14'
     libnl: '>=3.11.0,<4.0a0'
     rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
   hash:
-    md5: 4a7168d686b6125ba546134dddb16721
-    sha256: f64b69e48636871081fde0604ed37fac32a7146073ad2899550bcc0b14e7c09d
+    md5: 7d8c510157360d0a6fdd84a1d3db8de7
+    sha256: ba8de6a838bc0727ef8e5a1409c6735465b7b582627a9b4c2704126e53903f43
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.5.1-h84a0fba_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
   hash:
-    md5: 7e0759abab6964339520b84d0990c07a
-    sha256: 071a14074dbf7f7be2fb52798638e9a8194324bcb8deab50b452cc099729ea1c
+    md5: 5b0d1d64a7fe7e86900dd1859d2dd4d4
+    sha256: 267ab5fe990209b33de220432bcb595a88e6bb642e282bbe433a8edfdc811c1a
   category: main
   optional: false
 - name: libffi
@@ -6544,7 +6531,7 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -6554,14 +6541,14 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
   hash:
-    md5: 17d484ab9c8179c6a6e5b7dbb5065afc
-    sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
+    md5: 889febc66cd9e4190f80ef9718fa239b
+    sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6571,10 +6558,10 @@ package:
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.2-ha08bb59_0.conda
   hash:
-    md5: 62d6f3b832d7d79ae0c0aa1bb3c325fa
-    sha256: 3b32a7a710132d509f2ea38b2f0384414c863533e0fc7ac71b6a0763e4c67424
+    md5: 03123cafdc96cef79fc8a615f9119b79
+    sha256: 68ac66904a284a7dfbb3bdf9225380eaf20750b2d414215e6d7af5caa3ed1a63
   category: main
   optional: false
 - name: libglvnd
@@ -6628,6 +6615,96 @@ package:
   hash:
     md5: faac990cb7aedc7f3a2224f2c9b0c26c
     sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+  hash:
+    md5: fb4669c3990b94ea32fbb81f433e9aa6
+    sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e8d6e86663316dfbdec7dac532824516
+    sha256: 75860db66af9748572038d1e3a2260eca56ee4b38b9523e042fac8caf4277529
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+  hash:
+    md5: 99cf21100441e51272f1cd6fe0632a20
+    sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-devel-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e538f961a3042abf8307c5c5a6d6b09b
+    sha256: f3f74f090b6a31fed00d64cbe6bbeed6b2a9b820442714ecb66ada08dec913ea
   category: main
   optional: false
 - name: libhwloc
@@ -6950,6 +7027,68 @@ package:
     sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   category: main
   optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hd9031aa_0.conda
+  hash:
+    md5: e2834a423b3967e7b3b1e901c4a5f42f
+    sha256: cd11890a2c1f14d0342bfcbd81f97152d61dc71c27c7085efc13705a8f64f7c9
+  category: main
+  optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-hb427e8f_0.conda
+  hash:
+    md5: 39234f5550649043b04b3d73a2017f81
+    sha256: c14b5b584dc349df5ff5f6fa114d522090a0488fcb1599df0881fd53af45010c
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.10.5-h6406941_1.conda
+  hash:
+    md5: fa63517815747363c41b439ff9301db1
+    sha256: 7c9e562842f193f772ef0ba681f238a2d9e5ef637588b6e46eb30cc6aa1940c8
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libraqm-0.10.5-h45af499_1.conda
+  hash:
+    md5: fa1a27aaaa10e92be48372fa01573f7c
+    sha256: 7d88c506b9899d60e57f7456b02f54c7330029f2ad56c6df96357f981aa1bd96
+  category: main
+  optional: false
 - name: librsvg
   version: 2.62.3
   manager: conda
@@ -7044,31 +7183,30 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
   hash:
-    md5: 062b0ac602fb0adf250e3dfa86f221c4
-    sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+    md5: 4aed8e657e9ff156bdbe849b4df44389
+    sha256: 365376f4815e5e80def2b3462a2419708b7c292da0da85278386c2618621fff4
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.3-h1b79a29_0.conda
   hash:
-    md5: 1ebde5c677f00765233a17e278571177
-    sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+    md5: 7184d95871a58b8258a8ea124ed5aabc
+    sha256: a73a8acd97a6599fd6e561514db9f101ca7fd984cdc0cfd91ba74c8aa9dbe067
   category: main
   optional: false
 - name: libssh2
@@ -7206,16 +7344,16 @@ package:
   category: main
   optional: false
 - name: libuuid
-  version: 2.42.1
+  version: 2.42.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
   hash:
-    md5: 7d0a66598195ef00b6efc55aefc7453b
-    sha256: 3f0edf1280e2f6684a986f821eaa3e123d2694a00b31b96ca0d4a4c12c129231
+    md5: 01bb81d12c957de066ea7362007df642
+    sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
   category: main
   optional: false
 - name: libwebp-base
@@ -7428,15 +7566,15 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.7-hc7d1edf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
   hash:
-    md5: 7c6a5897a8bc5b6d509a4ee9dec7fcc8
-    sha256: 6bf27376f11198c01a88a1c8234470f45bce0aa7502b7e7988ef03ef5db3a890
+    md5: a9c118f6343fb6301b6f3b4e94c4c562
+    sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
   category: main
   optional: false
 - name: llvm-tools
@@ -7609,7 +7747,7 @@ package:
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7622,8 +7760,9 @@ package:
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
+    libraqm: '>=0.10.5,<0.11.0a0'
     libstdcxx: '>=14'
-    numpy: '>=1.23,<3'
+    numpy: '>=1.25,<3'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -7632,14 +7771,14 @@ package:
     python_abi: 3.12.*
     qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py312hc1765e9_1.conda
   hash:
-    md5: 7d499b5b6d150f133800dc3a582771c7
-    sha256: c7e133837376e53e6a52719c205a3067c42f05769bc3e8307417f8d817dfc63e
+    md5: 1d06d24525cf2e373310c1131acf12f8
+    sha256: d983b4ea15841f1fde4ccba4370485e89e696a447fcf5e90a1f75c8487699c68
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7652,7 +7791,8 @@ package:
     libcxx: '>=19'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    numpy: '>=1.23,<3'
+    libraqm: '>=0.10.5,<0.11.0a0'
+    numpy: '>=1.25,<3'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -7660,10 +7800,10 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.12.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py312hf3defc7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.0-py312h3b4889c_1.conda
   hash:
-    md5: e5d83f3ae6ada32d4e64e366a41f9ff6
-    sha256: c2dc997012fb8a901163cdad333ba5ba27733aa26d67a28a6501f4b4d69fcbce
+    md5: 892a539f6837bb1b1086f40eaae5a63e
+    sha256: 6d3eefa4d7c1d8e0bb58dc88fb0a91cc1691d940f9842a22477b465a75e5ce69
   category: main
   optional: false
 - name: matplotlib-inline
@@ -7792,29 +7932,29 @@ package:
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mizani
@@ -8119,27 +8259,27 @@ package:
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: nautilus-sampler
@@ -8386,39 +8526,39 @@ package:
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook-shim
@@ -9074,16 +9214,16 @@ package:
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9092,22 +9232,22 @@ package:
     python_abi: 3.12.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py312h50c33e8_0.conda
   hash:
-    md5: 9e5609720e31213d4f39afe377f6217e
-    sha256: fa291f8915114733dc1df9f1627b8c63c517217c1eee1a6ede2ceb5e368cf27a
+    md5: d749d04e1965315078f29320565c595a
+    sha256: 76b2e56c7a903a06be1210d35f35c2a8dcdc57912fda5c96b2e68acfd2b281fe
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9116,10 +9256,10 @@ package:
     python_abi: 3.12.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py312h4e908a4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.3.0-py312h4e908a4_0.conda
   hash:
-    md5: 0634560e556adb3e7924668e49ad53fc
-    sha256: f7ee5d45bf16184d2b53f0d35c98c06e4e82e21688ce93e52b55c02ec7153bf3
+    md5: 8c6be4560fc7cded72c7d17ddbe9cea4
+    sha256: 0867f0996be43d59afd9abf20a8374c2b33da88fe7a0c42fc98921b73a946426
   category: main
   optional: false
 - name: pip
@@ -9229,7 +9369,7 @@ package:
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -9240,14 +9380,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9258,10 +9398,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: pluggy
@@ -9976,7 +10116,7 @@ package:
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -9989,14 +10129,14 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10009,10 +10149,10 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pyobjc-core
@@ -10149,11 +10289,11 @@ package:
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10161,18 +10301,18 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10180,10 +10320,10 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest-cov
@@ -10478,7 +10618,7 @@ package:
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10486,24 +10626,24 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.11.0-py312h5253ce2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.12.0-py312h5253ce2_0.conda
   hash:
-    md5: 0a73899771633857390eac009995e5f9
-    sha256: 6aa36a62db36c2aa144640a3fba1cd3c61dd679a979288eae2fd3b9f89ef4eac
+    md5: 8ead1974106b7526f4866326654b99ff
+    sha256: 77a0592d53fe3664421926c32677f2829278de19d99c90ada80cd75286f34198
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: 3.12.*
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.11.0-py312hb3ab3e3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.12.0-py312hb3ab3e3_0.conda
   hash:
-    md5: ce26b141512a4261080d10847bc7afe3
-    sha256: 3e4a920f8be7ddc863e25fa430377f6fc1d1db301726a42dffc64b94d8cbe544
+    md5: 7aef8953d9a16dd831d61311db312be1
+    sha256: 5f3e2f02fb4284333e58c219be9026b9335064d1fe0df4b9cc4b991860288fba
   category: main
   optional: false
 - name: python-tzdata
@@ -10675,7 +10815,7 @@ package:
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -10684,14 +10824,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10700,10 +10840,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: quarto
@@ -11040,7 +11180,7 @@ package:
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -11048,42 +11188,42 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.5.1-py312h192e038_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py312h192e038_0.conda
   hash:
-    md5: a9e6fe6228340517c3b6a98bf5a76e2e
-    sha256: bc4a5045fd79e68392fb0661c698303c16e88b83d50626c2bc49c403555e900d
+    md5: 40984fba15f43a366ea4c6dea2b4c8bd
+    sha256: 4a190c74b5f3b441820a3142b03a489987c724b65237882ebe87d75892345d17
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.5.1-py312h8b1d842_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py312h8b1d842_0.conda
   hash:
-    md5: 196427409c7a36c934df2c261edb164f
-    sha256: 10b1a12941d3f905dbd139b809d94d569e9be48d146c31f5cad71bfe6ae25412
+    md5: ca4e32f2b1794e0e3ca071cc84995c4a
+    sha256: c9a1a6243ba1d20e4ccc6fb172259bbdfcc9bea95a2cbef8cd7f66330de35cc0
   category: main
   optional: false
 - name: s2n
-  version: 1.7.3
+  version: 1.7.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
   hash:
-    md5: f2bd09e21c5844a12e2f5eefcd075555
-    sha256: 150a0a5254e8b15ad737549721c7d13406cd96432f3f446e07073dbd98bb2491
+    md5: a20feedf58ce5441b115cebf284a9a75
+    sha256: de0bb8c7526684c9927cc687d4d07abe09d023a3ec950cfcd61089b495e2e616
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: linux-64
   dependencies:
@@ -11091,14 +11231,14 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11106,10 +11246,10 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: scikit-learn
@@ -11156,7 +11296,7 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -11168,17 +11308,17 @@ package:
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx: '>=14'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
   hash:
-    md5: 15995ecb2ef890778ba9a3750190f09d
-    sha256: d5ac05ad45c0d48731eb189c2cbb2bb99f0e3cb7e1acaad373cb2f1f2597fc75
+    md5: f8d242c552b0f7f682451ce95879af5e
+    sha256: c304dfb0bbf0d824d3706623f6437237d7bfc83941bb7b18f80e05abb10ec79e
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11189,13 +11329,13 @@ package:
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py312h4519d97_0.conda
   hash:
-    md5: 173d5eeba324363d9171946e86a81687
-    sha256: c0ed2cbfa3485bac8570e52b577475778c603ee92d078a8b164d1ddec992e577
+    md5: 5a352ca7e4f49ca6585dd30a4812bd20
+    sha256: 708f27ae8ccf62cf714dc5c6f728ae733dc14315c842e935ed7f491d214df2b0
   category: main
   optional: false
 - name: sdkroot_env_osx-arm64
@@ -11856,29 +11996,29 @@ package:
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: stack_data
@@ -12021,7 +12161,7 @@ package:
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12031,15 +12171,15 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12049,11 +12189,11 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tabulate
@@ -12279,29 +12419,29 @@ package:
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: traitlets
@@ -12329,7 +12469,7 @@ package:
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -12338,14 +12478,14 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12354,10 +12494,10 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: types-pyyaml
@@ -12674,27 +12814,27 @@ package:
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: webcolors
@@ -12820,7 +12960,7 @@ package:
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12828,38 +12968,38 @@ package:
     libgcc: '>=14'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.1-py312h4c3975b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py312h4c3975b_0.conda
   hash:
-    md5: a4d41bb00f252b99b4b903b3a8fa3ecc
-    sha256: 3d36b297c5f0c1ab0e598760f0033377334a3bfb5c12f4129c2abcb884e2d632
+    md5: 8555a1457e54a2b96093140db1b4b28b
+    sha256: 64ae5393d36cc553bcf05d3afbb42aef28b3d1fa986ed5c9358cd32d785940b7
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.1-py312h2bbb03f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py312h2bbb03f_0.conda
   hash:
-    md5: a82ae4e18607e068c9259136d07e4f87
-    sha256: baefb9a73519863a70f6e7a6f6acb982ee5485ae986a16960ff1e8cb99f1a023
+    md5: f7115a8060360996f419b397727293ab
+    sha256: 0ea6de1d6b8bc70b0fae3856e1e8c99c15f0fa5bb9863282b90f2da63ffcc953
   category: main
   optional: false
 - name: xkeyboard-config
-  version: '2.47'
+  version: '2.48'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
   hash:
-    md5: b56e0c8432b56decafae7e78c5f29ba5
-    sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
+    md5: b233b41be0bf210989d57160ed39b394
+    sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
   category: main
   optional: false
 - name: xorg-libice

--- a/.github/conda-lock/py3.13.conda-lock.yml
+++ b/.github/conda-lock/py3.13.conda-lock.yml
@@ -13,8 +13,8 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: a92e245a653492722a66d13be080ce30e0dad539306107d0713e606851790c84
-    osx-arm64: 6bca5cc48c9dd01551391293e6aef1b3e5056a6e1eedb8ded9a0091acfaadaa3
+    linux-64: a9af8fd27beb8e51581a4db76bd12292b705b6041e8e71e3f80dd8233a66734b
+    osx-arm64: 14ad3a78d2661baeb1f5d51ef6aad4cf8ac7c4ab75429a6ef783cf9272fb126f
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -178,7 +178,7 @@ package:
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -186,14 +186,14 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -201,10 +201,10 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: appnope
@@ -336,7 +336,7 @@ package:
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -345,14 +345,14 @@ package:
     cpython: '>=3.10'
     libgcc: '>=14'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.5.0-py310hd8a072f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.6.0-py310hd8a072f_0.conda
   hash:
-    md5: 6adea4814147f458d6278d053850b0ac
-    sha256: cf1cf3d0fa59fe0ab6bc3af722d820c1a85a9233c786f614f377c651fec6a7f9
+    md5: 530aaeffb462b062bf8e3abb66879cf0
+    sha256: 98eef90c96e2185254d12e667337077b989e9892167ff2c969e19b9296f42743
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -360,10 +360,10 @@ package:
     _python_abi3_support: 1.*
     cpython: '>=3.10'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.5.0-py310h3b8a9b8_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.6.0-py310h3b8a9b8_0.conda
   hash:
-    md5: 480f5277fd3ed13ea6ea8b5d74563815
-    sha256: 6c6e47ef2a85e7ade5c94d2388f43bd8197129e6b6305f9e8a49380b7dfbc427
+    md5: 9bc9209a773faadbdca5fe45d9aa9cdc
+    sha256: 0efbe4158ee4d5ff4108ad1b8c677e85eb1a8f3bb48fe2277579860d38e48315
   category: main
   optional: false
 - name: astroid
@@ -393,66 +393,66 @@ package:
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
     libgcc: '>=14'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-7.2.0-py313h29aa505_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-8.0.0-py313h29aa505_0.conda
   hash:
-    md5: 1ebbfdc7dcd587a6b6cc9f78db302b8d
-    sha256: 87fe9cc7bd7271432abc9aa7ecd79292e5bab2cdcd698a8dc412e3156019e810
+    md5: 724669f98b218598298705c44e4d157d
+    sha256: 1adc011d8ab8cd3f7e765ddf1f933e778eda000d01b572671920e9989852430e
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-7.2.0-py313hc577518_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-8.0.0-py313hf5115c3_0.conda
   hash:
-    md5: 43c0025a978822284cb04d1df8bb0447
-    sha256: 6ee5f0049902fc5a61af0743580235599032100ebc67a2ec77a48d4285c2ff7e
+    md5: 89e782220f37f766fadc8d3e94ad24d8
+    sha256: 9062a8a102c9ff057f903572d0ef8d0c6b38c04d5e56bcbddb9f18c130a17c70
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: asttokens
@@ -601,12 +601,12 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
   hash:
-    md5: c463d2dbfb12a208c943165d2a568db4
-    sha256: 5b9c20a38fe084b4ffd1f2c64b3797ec6ef9a99e83cc0c1f84e016c9801e3a5c
+    md5: 9329dcd00c4d61aa49e516dddd784e91
+    sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
   category: main
   optional: false
 - name: aws-c-auth
@@ -619,11 +619,11 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
   hash:
-    md5: e7501df14d3145fc86943ebfeb76a402
-    sha256: b4689664156e8067ba1aa97125f2a309a96b2bc0d1c608f4a88f30ea1f4c9aba
+    md5: 1fc365a60432d78b729d1468fce1b6c9
+    sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
   category: main
   optional: false
 - name: aws-c-cal
@@ -748,11 +748,11 @@ package:
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-    s2n: '>=1.7.3,<1.7.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h5b668fc_4.conda
+    s2n: '>=1.7.4,<1.7.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
   hash:
-    md5: 555400dce62f2d989ff77761c010d166
-    sha256: c27b972325342f062da00b7aa2d5abf6f3ce55668a05703a175be958745cc226
+    md5: 12697e83c2a0e5b93fd03855a70eb360
+    sha256: c798005b65bc74d02aba1db01d4d344c4e72662f0beef35fbdd35b4695c197de
   category: main
   optional: false
 - name: aws-c-io
@@ -763,14 +763,14 @@ package:
     __osx: '>=11.0'
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
   hash:
-    md5: b33f51eca94f6ccbd772ca4043fe1718
-    sha256: 18f51bdc45eabe01ca68edf5ccc73369b3201639790575e6776f3efaea6e4356
+    md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
+    sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -782,15 +782,15 @@ package:
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
   hash:
-    md5: 70bc8e5e8cefd19407423733e7ebf540
-    sha256: 8f193173f1dccb25ff86a95543db27f0c762cccfe93157b02cf20bd5b4c11a92
+    md5: f2b6275244daa12109bcd0a126f1fb85
+    sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -801,37 +801,37 @@ package:
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
   hash:
-    md5: 7dc63973f9fe772985b8c2f8ba5958ce
-    sha256: 0a99b506bbe21f00f21047db50b2eea2ff8a0b1146ff0fba7d04b39a568453f4
+    md5: 912c61c44a2782693d63af2272551455
+    sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
   hash:
-    md5: 4b66ac29a7e917a629b790c3d239d110
-    sha256: 123c4325b16f1f6db95846d51e5e4201399ee29c0325f8b5a8db2e7d732b9151
+    md5: 5088795f3dfcf00a26f03c2a17ae8429
+    sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
   hash:
-    md5: 127bce41f9e6cc3bdb9e6daed95896d9
-    sha256: ef53cd1e30bc8c865c44df6f097f36361945665157e63957d68fe90aa7e4d66c
+    md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
+    sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
   category: main
   optional: false
 - name: aws-checksums
@@ -886,7 +886,7 @@ package:
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -895,14 +895,14 @@ package:
     python: ''
     python_abi: 3.13.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py313h18e8e13_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.6.0-py313h18e8e13_0.conda
   hash:
-    md5: 0de0c2c1f2677ea074bdda91de5a4c01
-    sha256: 310e114a783b249517d1dd6e74b3f339af30e947bc93446ae4e4e9c86fff7478
+    md5: fbc7d3707f09cae6648e6eb1b6203a5c
+    sha256: d7aca2b34335035ef80eaaebff4e5a0ae524b6f3792a82a144d38c4a81f42916
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -910,10 +910,10 @@ package:
     python: ''
     python_abi: 3.13.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.5.0-py313h7208f8c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.6.0-py313h7208f8c_0.conda
   hash:
-    md5: 27b54f7bbc635f824806978d9d201573
-    sha256: 3ff16bb31de2cd6699804388337a6efa8a33c12850b5387b13ef38460ca605a3
+    md5: 6ab3d07883ad437c12a8f5fd90c1df5b
+    sha256: 4d39bf744249f60212a728369dbc6cd6ec4d5aef6668a14321f747d7eb4bac2d
   category: main
   optional: false
 - name: beautifulsoup4
@@ -1247,7 +1247,7 @@ package:
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -1257,14 +1257,14 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.3-hc31b594_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.5-hc31b594_0.conda
   hash:
-    md5: 2f0eb57a686a4e27719ce0b0076784a1
-    sha256: 4029fb93e133c0de986464c2f1b02630f141f976cb25b5b929994b34a2a51bf5
+    md5: 76ea4a0e8f1600f89cbb2d3d62ac2b04
+    sha256: 6e42591b70252b4e91a3391894c570e45d7f1f21b20937c8f57f16e3cf659e5d
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1273,10 +1273,10 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.3-hf9886e1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.5-hf9886e1_0.conda
   hash:
-    md5: 8cbeea5e4377be5f486b94ee658590a9
-    sha256: 828449a87f57b4ccb793f1db645cf9d5a816186d978de6df31b053a57b248204
+    md5: c70b84faedf42fe923b584a587159081
+    sha256: a2db3ad1b7fedc40b3436d5382415bb63faac2baf69142c369f6040b71aeb8be
   category: main
   optional: false
 - name: c-compiler
@@ -1309,27 +1309,27 @@ package:
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: cached-property
@@ -1524,27 +1524,27 @@ package:
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: cffi
@@ -1907,18 +1907,6 @@ package:
     sha256: 01f02e9baa51ef2debfdc55df57ea6a7fce9b5fb9356c3267afb517e1dc4363a
   category: main
   optional: false
-- name: conda-gcc-specs
-  version: 14.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gcc_impl_linux-64: '>=14.3.0,<14.3.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_19.conda
-  hash:
-    md5: fd57230e9a97b97bf20dd63aeae6fe61
-    sha256: 769357d82d19f59c23888d935d92b67739bdb2acaacaa7bbe7c4fe4ee5346287
-  category: main
-  optional: false
 - name: contourpy
   version: 1.3.3
   manager: conda
@@ -2102,7 +2090,7 @@ package:
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -2111,14 +2099,14 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.1-py313h3dea7bd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.3-py313h3dea7bd_0.conda
   hash:
-    md5: 86bbb569988f077e5cb30acac5799599
-    sha256: b4ff99ffe4e60119c2f99fa29234b4267f7e0f43dbf5396dad0f8adaf95284e2
+    md5: ae7823c5693b8d58d5d26f3ecc1be9c0
+    sha256: 03524907f2d141ce198ca16f76c105daffa3ff2ad3c710db34fc8d57d2603041
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2126,36 +2114,36 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.1-py313h65a2061_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.3-py313h65a2061_0.conda
   hash:
-    md5: e3f15d7b559de10dd9f60bd345efcdaa
-    sha256: 46d98e0d517ecf6bff6160b2200a27f88da681786d4eb223cd5949d73a0b7610
+    md5: b087cd0441275628d2f3d59744f86316
+    sha256: d2730d071b5c0f1a000b04f513b6d2d949684a500d569ce9bf7ed5ffab5596e0
   category: main
   optional: false
 - name: cpython
-  version: 3.13.13
+  version: 3.13.14
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.13,<3.14.0a0'
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
   hash:
-    md5: 3a8a8b87e72f95b54689fb588e154ec9
-    sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
+    md5: 22ff6a23190a29024b0df04b4caa0c66
+    sha256: 42995d97d7e83d2bedbe8173bc9aa022ea412bf33dd2ff0e3db2c01a5242cd0a
   category: main
   optional: false
 - name: cpython
-  version: 3.13.13
+  version: 3.13.14
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.13,<3.14.0a0'
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
   hash:
-    md5: 3a8a8b87e72f95b54689fb588e154ec9
-    sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
+    md5: 22ff6a23190a29024b0df04b4caa0c66
+    sha256: 42995d97d7e83d2bedbe8173bc9aa022ea412bf33dd2ff0e3db2c01a5242cd0a
   category: main
   optional: false
 - name: cxx-compiler
@@ -2210,7 +2198,7 @@ package:
   category: main
   optional: false
 - name: cython
-  version: 3.2.5
+  version: 3.2.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -2219,14 +2207,14 @@ package:
     libstdcxx: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.5-py313hc80a56d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.8-py313hc80a56d_0.conda
   hash:
-    md5: de852c4e3836da77a1bd5de949adff12
-    sha256: b1483f3802a006b9459eca7b1335718f778db2acb15701b685b4a9e60d4f6003
+    md5: 471a30266bb84c71187f841084ab8ecc
+    sha256: 584ba87e7f78071bd9cbd7082e880d119125b292f63113014ba84d12af75402d
   category: main
   optional: false
 - name: cython
-  version: 3.2.5
+  version: 3.2.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2234,32 +2222,32 @@ package:
     libcxx: '>=19'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.5-py313hf5aebd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.8-py313hd1249e6_0.conda
   hash:
-    md5: 039b3f683001e8632650a140fa48c150
-    sha256: fb07b343d978d4db325cfb07aa309f6ac4fd533871b5385a06a4983e081d9250
+    md5: 1f611c92ab78d3bdffa463f8b8343f79
+    sha256: c1f12f8d07f574f580c60082cb01f721fae87ec411453ad13cb047cb97f6226e
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.100.0-hfc2019e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.101.0-hfc2019e_0.conda
   hash:
-    md5: 97b46522187a0064a52207a3ca68621c
-    sha256: 43146af49e6911c7bc57eedfdb945cb3ecbaa73e9565e84099229345edebe0c5
+    md5: 3c5956f8de352968510d857a1dfdf929
+    sha256: 624d4599a0b72315473a8854a4abbafc4e2a774b2bd8e64788823a798546321c
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.100.0-h820172f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.101.0-h820172f_0.conda
   hash:
-    md5: 2ae10fcbebb03cae94eefc1ec6311956
-    sha256: c4595381f35451b995af233fd4fe40aa4e56497d8d5d4110250f71df0e71003a
+    md5: 0271842f65ca34de8326cf8dbd38dda8
+    sha256: cafab0396ee8c6e24c0401d71be1669852a03e11cf130cf394b65382fe88ae7f
   category: main
   optional: false
 - name: dbus
@@ -2667,25 +2655,25 @@ package:
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.0-hfc2019e_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.1-hfc2019e_0.conda
   hash:
-    md5: 436dd09d9b9e59414bf803453795c5b5
-    sha256: e06f972eee640fe5ece7931e97bf9d317589fa9798ad19fa5c8761a7e393ace7
+    md5: 65b5461adebff76dc54e02c5c19a20a8
+    sha256: 2ff0603150014c840474d0ddc8813569d91f9ab20e83cb49b1019eb4155c0a63
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.0-hf76c51c_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.1-hf76c51c_0.conda
   hash:
-    md5: 8d9633a86fd47d9244f14f98f1d5c094
-    sha256: 73a69d92e36d9f6889ed080fc1e3cbe3ac94c9e5d6b3683c1792acf0fd86f043
+    md5: 7023b247571c6428ac7752c87193d68d
+    sha256: 340c65b3acdbe58b815b363304f93a25dd5cfd96bc0479b24f3d656b71522853
   category: main
   optional: false
 - name: exceptiongroup
@@ -3358,12 +3346,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    conda-gcc-specs: ''
     gcc_impl_linux-64: 14.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_19.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h6f77f03_19.conda
   hash:
-    md5: 2dd149aa693db92758af3e685ef30439
-    sha256: e3f541c4be7296b800a972482b7a5e399614d5e3310d3d083257fbdb4df81ea0
+    md5: 444fafd4d1acdfe80c49b559a2569ba1
+    sha256: 5c86862941a44b2554e23e623ddb8f18c95474cacf536635e38ee431385b7d4a
   category: main
   optional: false
 - name: gcc_impl_linux-64
@@ -3393,46 +3380,46 @@ package:
     binutils_linux-64: ''
     gcc_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
   hash:
-    md5: c75730101e8fcefeb3867aa52954bf76
-    sha256: 1a1736aaa63271c782cbe79353560f272cc889447bcab6000201e924eb9a6a27
+    md5: 90369fa27fae2f7bf7eaaccc34c793e2
+    sha256: d7f427d6db94a5eed2a43b186f8dc17cc1fbeb03517442390a36f1cde02548b0
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libglib: '>=2.88.2,<3.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.7-h2b0a6b4_0.conda
   hash:
-    md5: 7892f39a39ed39591a89a28eba03e987
-    sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
+    md5: 5d355db3e937086e22cf4cb5fe19787c
+    sha256: 1c22e37f9d7e06e9e0582ee5a55c2ddd19ea75f71f44eb13b56f504ef5c37aa5
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.2,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.6-h4e57454_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.7-h4e57454_0.conda
   hash:
-    md5: e67ebd2f639f46e52af8531622fa6051
-    sha256: 07cbba4e12430de35ea608eb3006cf1f7f63832c4f89a081cd6f3872944c1aa6
+    md5: f717a22e13a1499c9552ffff02d22d64
+    sha256: 69bb2e62a93f6407c9e9ccd4d21fe4d4e5373d64eecd6c5df318144ca4c80953
   category: main
   optional: false
 - name: getdist
@@ -3501,13 +3488,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    gcc: 14.3.0.*
-    gcc_impl_linux-64: 14.3.0.*
-    gfortran_impl_linux-64: 14.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran-14.3.0-he448592_7.conda
+    gcc: 14.3.0
+    gcc_impl_linux-64: 14.3.0
+    gfortran_impl_linux-64: 14.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran-14.3.0-h76987e4_19.conda
   hash:
-    md5: 94394acdc56dcb4d55dddf0393134966
-    sha256: 7ab008dd3dc5e6ca0de2614771019a1d35480d51df6216c96b1cf6a5e660ee40
+    md5: e4715f9886de7b78aefdfe74f01e739b
+    sha256: 84b3b7863dbafb651a2ef989d50f5e3d985b8ebe78bb3df2f17c614f22cdc090
   category: main
   optional: false
 - name: gfortran
@@ -3573,10 +3560,10 @@ package:
     gcc_linux-64: ==14.3.0
     gfortran_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-hd59e7da_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-h5ce6d8a_27.conda
   hash:
-    md5: 2ff2d83810d91869f20abb7e28c4d7da
-    sha256: 2e140d31ecbc74c44ab03e3fd40f51af2a0861ad399526205801bc0cd3ff5061
+    md5: cedd6fb9fad7611ee0bcb0fb531d77f1
+    sha256: b8e6bd99f0b7a5e8757a1cf9bf64edc6217206d8872fb9af5d8204e5b581b3d1
   category: main
   optional: false
 - name: gfortran_osx-arm64
@@ -3639,65 +3626,65 @@ package:
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.1-hd810c12_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.2-hbe0478d_0.conda
   hash:
-    md5: 9add1716591862a115c885dda4fcbeb5
-    sha256: 6a97b61cfb30a85c2f4a95f1f7525a873eea0b540f9f11b9cf31ad70d6635fce
+    md5: 7ac6295be13fafd7f20869b30b47ec2f
+    sha256: 84448dc33e66a2c74c58fb2a95d9e84547bc65cf44dcebf447b8d236c0ccc68b
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
     libintl-devel: ''
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.1-h92d5a4f_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.2-h2792883_0.conda
   hash:
-    md5: 937bab93d8e05d664f45f1aed40291ba
-    sha256: e6804164a3d771d369d97fd08a2db739321d452c9ffa6803f9bbf309aa1f4dfe
+    md5: a53abd3898d5addc45f164e8c5dbef50
+    sha256: 74b4c85756d2584abf3972035a3d68edd5b723527460a261b6df21bfe6980f7e
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libffi: ''
     libgcc: '>=14'
-    libglib: ==2.88.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda
+    libglib: ==2.88.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.2-h8094192_0.conda
   hash:
-    md5: e5a459d2bb98edb88de5a44bfad66b9d
-    sha256: ae41fd5c867bc4e713a8cc1dc06f5b418026fec116cc222abe33e94235c6b241
+    md5: cfe66c21ae651b84a3d25a1dbb641a54
+    sha256: 079757e4e0497d67505b52062668e4cc0d2a86ec065ae2c0c57487a178206061
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libffi: ''
-    libglib: ==2.88.1
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.1-h37541a8_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.2-h246a70f_0.conda
   hash:
-    md5: 8d4580a91948a6c3383a7c2fbfe5311c
-    sha256: 414bdf86a8096d5706293d163359def2e61b8ffd3fe106bbf2028d79e58e6a97
+    md5: 973a5ef252899cd0916418c75a864169
+    sha256: 6a98eabd4d5bb902c391e9f7c9e655ce61292ff6f1bb0c592da42fd66e6c89f9
   category: main
   optional: false
 - name: gmp
@@ -4013,12 +4000,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    gcc: 14.3.0.*
-    gxx_impl_linux-64: 14.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
+    gcc: 14.3.0
+    gxx_impl_linux-64: 14.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_19.conda
   hash:
-    md5: 91dc0abe7274ac5019deaa6100643265
-    sha256: 7acf0ee3039453aa69f16da063136335a3511f9c157e222def8d03c8a56a1e03
+    md5: 1167f6b6bfaf9ba5a450c5c8f3a21795
+    sha256: 32ff46517d91ee041287687d65140f7b0e8d08bb3fca141e5f97cc4a7ad7e255
   category: main
   optional: false
 - name: gxx_impl_linux-64
@@ -4045,10 +4032,10 @@ package:
     gcc_linux-64: ==14.3.0
     gxx_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h175a97f_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
   hash:
-    md5: 1bfdaeeea0b3d0031d9ad755296afbce
-    sha256: 89d8a3268bafb3f80e95ab9a4a062f332b11be836789cebd9ec490ccf3eb7428
+    md5: 41fae38a424bbc78438cfec6a4fde187
+    sha256: cf5a44d14732b79e3c2bc6ebe1dba4f6b9077939f3093c75e36ad340737b5c15
   category: main
   optional: false
 - name: h11
@@ -4145,21 +4132,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libglib: '>=2.88.1,<3.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
   hash:
-    md5: 21ee4640b7c2d94e584349fa12b29b9a
-    sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
+    md5: 72e956a71241633d8c80aa198fd08784
+    sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
   category: main
   optional: false
 - name: harfbuzz
@@ -4167,20 +4144,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libcxx: '>=19'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libglib: '>=2.88.1,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-hce30654_1.conda
   hash:
-    md5: 389b1c7cb4738fa74f8a142336807a13
-    sha256: 5593f4aad6580707eb268e8dbb4c562a736d87bea03f5e1551becaebfe1a6620
+    md5: 95896299aa1012c7410629b2ee360f87
+    sha256: 8922ec1cd17f558ca38c513d4880b7fadbfa08b38a563880c8c2ceddfcc1fba2
   category: main
   optional: false
 - name: hdf5
@@ -4193,8 +4161,8 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
@@ -4202,11 +4170,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
   hash:
-    md5: b1b444bca8da3ff6cc4afad1fa7f7d61
-    sha256: ff8336394dcfaccf49e56d1dd66091cf767df0d3d33f3fa440c980e0445b34cc
+    md5: 3c126667b98ad8ccf390a91b9097f574
+    sha256: 8225145aababbef3f8900b651cfa4ac9257cd4d522957711f469f6ea5b504761
   category: main
   optional: false
 - name: hdf5
@@ -4219,19 +4187,19 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
   hash:
-    md5: fb804a23360d2b40c4f9d15a8bf0b869
-    sha256: 67e9ef0dfd22a37ff51d0b19aa35e9f7da21739a624976bcac1f72ab1698e8f8
+    md5: 5cc8ba7775f6694349b7a71837bbad90
+    sha256: 8f37c0185801b81a50e4e1430501ddd1c9bfe5e6a5e4ea3c61464e0f1d9199aa
   category: main
   optional: false
 - name: healpy
@@ -4304,27 +4272,27 @@ package:
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: httpcore
@@ -4418,7 +4386,7 @@ package:
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -4428,14 +4396,14 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4445,10 +4413,10 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: icu
@@ -4478,27 +4446,27 @@ package:
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: imagesize
@@ -4549,32 +4517,6 @@ package:
   hash:
     md5: ffc17e785d64e12fc311af9184221839
     sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
   category: main
   optional: false
 - name: iniconfig
@@ -4653,7 +4595,7 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4670,14 +4612,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4694,10 +4636,10 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython_pygments_lexers
@@ -4825,29 +4767,29 @@ package:
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jinja2
@@ -4903,27 +4845,27 @@ package:
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: jsonpointer
@@ -5084,6 +5026,36 @@ package:
   hash:
     md5: 9453512288d20847de4356327d0e1282
     sha256: b538e15067d05768d1c0532a6d9b0625922a1cce751dd6a2af04f7233a1a70e9
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
   category: main
   optional: false
 - name: jupyter-lsp
@@ -5261,7 +5233,7 @@ package:
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5284,14 +5256,14 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5314,10 +5286,10 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server_terminals
@@ -5347,7 +5319,7 @@ package:
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -5355,25 +5327,25 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5381,21 +5353,21 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab_pygments
@@ -5551,11 +5523,11 @@ package:
     libedit: '>=3.1.20250104,<4.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
   hash:
-    md5: fb53fb07ce46a575c5d004bbc96032c2
-    sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
   category: main
   optional: false
 - name: krb5
@@ -5566,11 +5538,11 @@ package:
     __osx: '>=11.0'
     libcxx: '>=19'
     libedit: '>=3.1.20250104,<4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
   hash:
-    md5: e446e1822f4da8e5080a9de93474184d
-    sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+    md5: 8780f41b013d19219faef9c82260744b
+    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
   category: main
   optional: false
 - name: lark
@@ -5926,7 +5898,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5934,44 +5906,46 @@ package:
     krb5: '>=1.22.2,<1.23.0a0'
     libgcc: '>=14'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
   hash:
-    md5: c3cc2864f82a944bc90a7beb4d3b0e88
-    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+    md5: f9c59d277a16ec8f272b2d5dd2ec3335
+    sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     krb5: '>=1.22.2,<1.23.0a0'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h1359186_2.conda
   hash:
-    md5: 2f57b7d0c6adda88957586b7afd78438
-    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+    md5: dfe89fb0539ad4611998a5c6905692ff
+    sha256: b21aec36796a7d9b3c8b634f2d466c1d0a2658b2e57aa4686285cf4c10d5c227
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
   hash:
-    md5: 0325fbe13eb6dd39234eb305ac1b3cb8
-    sha256: cceb668dc1b71f054b1036dd83eca2e02c0c3a4b2ba3ad28c74a982d819597a3
+    md5: 89f76a2a21a3ec3ec983b5eb237c4113
+    sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
   category: main
   optional: false
 - name: libcxx-devel
@@ -6155,31 +6129,31 @@ package:
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
   hash:
-    md5: 0b82ff1ab3db9122f20cafe93f61bc3b
-    sha256: c2b53beed03c735b18116d5227410b15cc9fbef209795212afd179f8c8a5fd70
+    md5: b04e60c49d09399a009f3bb70bb53a23
+    sha256: 45bb0eb92000a3f82555cc948013935aace8a1ea522b79700f58d3906c18e846
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.5.1-hce30654_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
   hash:
-    md5: fbd3f6f592ca4d3c404c303c1c5d89bd
-    sha256: e792acfdeb39c508640f5558ef79d190c88c589edc1e00605a44159af0cadf34
+    md5: b92a04dd36f41b0d8dfed62ff7812eea
+    sha256: 048eb6e03202b5a6f8ecbcdeb5a3f5ac9702736aa494de6615639d60ff68adc9
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -6187,22 +6161,22 @@ package:
     libgcc: '>=14'
     libnl: '>=3.11.0,<4.0a0'
     rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
   hash:
-    md5: 4a7168d686b6125ba546134dddb16721
-    sha256: f64b69e48636871081fde0604ed37fac32a7146073ad2899550bcc0b14e7c09d
+    md5: 7d8c510157360d0a6fdd84a1d3db8de7
+    sha256: ba8de6a838bc0727ef8e5a1409c6735465b7b582627a9b4c2704126e53903f43
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.5.1-h84a0fba_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
   hash:
-    md5: 7e0759abab6964339520b84d0990c07a
-    sha256: 071a14074dbf7f7be2fb52798638e9a8194324bcb8deab50b452cc099729ea1c
+    md5: 5b0d1d64a7fe7e86900dd1859d2dd4d4
+    sha256: 267ab5fe990209b33de220432bcb595a88e6bb642e282bbe433a8edfdc811c1a
   category: main
   optional: false
 - name: libffi
@@ -6556,7 +6530,7 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -6566,14 +6540,14 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
   hash:
-    md5: 17d484ab9c8179c6a6e5b7dbb5065afc
-    sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
+    md5: 889febc66cd9e4190f80ef9718fa239b
+    sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6583,10 +6557,10 @@ package:
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.2-ha08bb59_0.conda
   hash:
-    md5: 62d6f3b832d7d79ae0c0aa1bb3c325fa
-    sha256: 3b32a7a710132d509f2ea38b2f0384414c863533e0fc7ac71b6a0763e4c67424
+    md5: 03123cafdc96cef79fc8a615f9119b79
+    sha256: 68ac66904a284a7dfbb3bdf9225380eaf20750b2d414215e6d7af5caa3ed1a63
   category: main
   optional: false
 - name: libglvnd
@@ -6640,6 +6614,96 @@ package:
   hash:
     md5: faac990cb7aedc7f3a2224f2c9b0c26c
     sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+  hash:
+    md5: fb4669c3990b94ea32fbb81f433e9aa6
+    sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e8d6e86663316dfbdec7dac532824516
+    sha256: 75860db66af9748572038d1e3a2260eca56ee4b38b9523e042fac8caf4277529
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+  hash:
+    md5: 99cf21100441e51272f1cd6fe0632a20
+    sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-devel-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e538f961a3042abf8307c5c5a6d6b09b
+    sha256: f3f74f090b6a31fed00d64cbe6bbeed6b2a9b820442714ecb66ada08dec913ea
   category: main
   optional: false
 - name: libhwloc
@@ -6975,6 +7039,68 @@ package:
     sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   category: main
   optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hd9031aa_0.conda
+  hash:
+    md5: e2834a423b3967e7b3b1e901c4a5f42f
+    sha256: cd11890a2c1f14d0342bfcbd81f97152d61dc71c27c7085efc13705a8f64f7c9
+  category: main
+  optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-hb427e8f_0.conda
+  hash:
+    md5: 39234f5550649043b04b3d73a2017f81
+    sha256: c14b5b584dc349df5ff5f6fa114d522090a0488fcb1599df0881fd53af45010c
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.10.5-h6406941_1.conda
+  hash:
+    md5: fa63517815747363c41b439ff9301db1
+    sha256: 7c9e562842f193f772ef0ba681f238a2d9e5ef637588b6e46eb30cc6aa1940c8
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libraqm-0.10.5-h45af499_1.conda
+  hash:
+    md5: fa1a27aaaa10e92be48372fa01573f7c
+    sha256: 7d88c506b9899d60e57f7456b02f54c7330029f2ad56c6df96357f981aa1bd96
+  category: main
+  optional: false
 - name: librsvg
   version: 2.62.3
   manager: conda
@@ -7069,31 +7195,30 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
   hash:
-    md5: 062b0ac602fb0adf250e3dfa86f221c4
-    sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+    md5: 4aed8e657e9ff156bdbe849b4df44389
+    sha256: 365376f4815e5e80def2b3462a2419708b7c292da0da85278386c2618621fff4
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.3-h1b79a29_0.conda
   hash:
-    md5: 1ebde5c677f00765233a17e278571177
-    sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+    md5: 7184d95871a58b8258a8ea124ed5aabc
+    sha256: a73a8acd97a6599fd6e561514db9f101ca7fd984cdc0cfd91ba74c8aa9dbe067
   category: main
   optional: false
 - name: libssh2
@@ -7231,16 +7356,16 @@ package:
   category: main
   optional: false
 - name: libuuid
-  version: 2.42.1
+  version: 2.42.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
   hash:
-    md5: 7d0a66598195ef00b6efc55aefc7453b
-    sha256: 3f0edf1280e2f6684a986f821eaa3e123d2694a00b31b96ca0d4a4c12c129231
+    md5: 01bb81d12c957de066ea7362007df642
+    sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
   category: main
   optional: false
 - name: libwebp-base
@@ -7453,15 +7578,15 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.7-hc7d1edf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
   hash:
-    md5: 7c6a5897a8bc5b6d509a4ee9dec7fcc8
-    sha256: 6bf27376f11198c01a88a1c8234470f45bce0aa7502b7e7988ef03ef5db3a890
+    md5: a9c118f6343fb6301b6f3b4e94c4c562
+    sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
   category: main
   optional: false
 - name: llvm-tools
@@ -7634,7 +7759,7 @@ package:
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7647,8 +7772,9 @@ package:
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
+    libraqm: '>=0.10.5,<0.11.0a0'
     libstdcxx: '>=14'
-    numpy: '>=1.23,<3'
+    numpy: '>=1.25,<3'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -7657,14 +7783,14 @@ package:
     python_abi: 3.13.*
     qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py313h683a580_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py313h6c470cf_1.conda
   hash:
-    md5: 4265d85b1d706caba7ac1d73b5f43dee
-    sha256: ae0233aa03da84e0964a4c214faaa9d0735575714529a7f2ebe96bc712c276bf
+    md5: 1a3cd18fa2cfd6048c4e052ff9d9ff26
+    sha256: e6335a7fcb1cc9c6dd0aae18bed34080764dda4486c314505536e84e38fde69b
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7677,7 +7803,8 @@ package:
     libcxx: '>=19'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    numpy: '>=1.23,<3'
+    libraqm: '>=0.10.5,<0.11.0a0'
+    numpy: '>=1.25,<3'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -7685,10 +7812,10 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.13.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py313h36cb854_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.0-py313ha8b9ad1_1.conda
   hash:
-    md5: 31b565206ed2d71a0a6cca1e54e3f2c5
-    sha256: c58141d2971d2c16cc10e0870635ecd4a64ca89aa0b107d3c1afa3d382f99490
+    md5: 48623b37cfd19caac83dde76836cd4d1
+    sha256: 7dbf910d3ba9f7627fe337f84d76cb2e804e9f62c2c8f2fa0bc08f2206e5e61d
   category: main
   optional: false
 - name: matplotlib-inline
@@ -7817,29 +7944,29 @@ package:
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mizani
@@ -8142,27 +8269,27 @@ package:
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: nautilus-sampler
@@ -8409,39 +8536,39 @@ package:
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook-shim
@@ -9101,16 +9228,16 @@ package:
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9119,22 +9246,22 @@ package:
     python_abi: 3.13.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py313h80991f8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py313h80991f8_0.conda
   hash:
-    md5: 7245f1bbf52ed5e3818d742f51b44a7d
-    sha256: 55a76548bb003ff6deac9bf209b279d428030f230632fb70f15ae153aed05158
+    md5: 730e462e7e141813192b606cf07ebdd0
+    sha256: cb3e51a639d19e04d0ea197ff6f6805a40eeef92d762642f28fa1cd1d25f672a
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9143,10 +9270,10 @@ package:
     python_abi: 3.13.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py313h45e5a15_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.3.0-py313h45e5a15_0.conda
   hash:
-    md5: 6186601fd72a394a6f7c7b7096f6a063
-    sha256: 90333643a7868b10724999633bb393d005bc5f539d05666f80c41fb67e5f0f3f
+    md5: da5b19ecf11bee5d980d5f793a80feec
+    sha256: 98bd4dd560714b500ab2056664beae514993a861364dffc941bd661ab086f726
   category: main
   optional: false
 - name: pip
@@ -9252,7 +9379,7 @@ package:
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -9263,14 +9390,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9281,10 +9408,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: pluggy
@@ -9999,7 +10126,7 @@ package:
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -10012,14 +10139,14 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10032,10 +10159,10 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pyobjc-core
@@ -10172,11 +10299,11 @@ package:
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10184,18 +10311,18 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10203,10 +10330,10 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest-cov
@@ -10322,56 +10449,56 @@ package:
   category: main
   optional: false
 - name: python
-  version: 3.13.13
+  version: 3.13.14
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
     libgcc: '>=14'
-    liblzma: '>=5.8.2,<6.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.52.0,<4.0a0'
-    libuuid: '>=2.42,<3.0a0'
+    libsqlite: '>=3.53.2,<4.0a0'
+    libuuid: '>=2.42.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
   hash:
-    md5: 05051be49267378d2fcd12931e319ac3
-    sha256: 7f77eb57648f545c1f58e10035d0d9d66b0a0efb7c4b58d3ed89ec7269afdde1
+    md5: 93762cd272814a142cf21d794f8fb0c1
+    sha256: f2146aff59ce4b571a8f1d1acf94f9bed6cc18ab5632d7dcc940fb48ecdeef99
   category: main
   optional: false
 - name: python
-  version: 3.13.13
+  version: 3.13.14
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.52.0,<4.0a0'
+    libsqlite: '>=3.53.2,<4.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
   hash:
-    md5: 9991a930e81d3873eba7a299ba783ec4
-    sha256: d0fffc5fde21d1ae350da545dfb9e115a8c53bed8a9c5761f9efd4a5581853c1
+    md5: e556c07deaa168043f8430bb046092e2
+    sha256: c89eedab6b293fae654d75483d8f3e5eb3ff9ce2478134d902676c1dd20c7dfd
   category: main
   optional: false
 - name: python-dateutil
@@ -10425,29 +10552,29 @@ package:
   category: main
   optional: false
 - name: python-gil
-  version: 3.13.13
+  version: 3.13.14
   manager: conda
   platform: linux-64
   dependencies:
-    cpython: 3.13.13.*
+    cpython: 3.13.14.*
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
   hash:
-    md5: fd00e4b24ea88093c93f5c9bad27b52f
-    sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
+    md5: 200323d73f85b9c5c411db8c8c4942db
+    sha256: c7a8f98ea1cda5a84377c236ccd4bf1b6e2212c5a258d60bba295fb9f0260235
   category: main
   optional: false
 - name: python-gil
-  version: 3.13.13
+  version: 3.13.14
   manager: conda
   platform: osx-arm64
   dependencies:
-    cpython: 3.13.13.*
+    cpython: 3.13.14.*
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
   hash:
-    md5: fd00e4b24ea88093c93f5c9bad27b52f
-    sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
+    md5: 200323d73f85b9c5c411db8c8c4942db
+    sha256: c7a8f98ea1cda5a84377c236ccd4bf1b6e2212c5a258d60bba295fb9f0260235
   category: main
   optional: false
 - name: python-json-logger
@@ -10503,7 +10630,7 @@ package:
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10511,24 +10638,24 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.11.0-py313h54dd161_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.12.0-py313h54dd161_0.conda
   hash:
-    md5: 268aef8a914b61322ca2b51500652a7a
-    sha256: 5b08c4caeced10f7354db4abd10e14c03634edb2bb6bc39695329cbfe0ca48a9
+    md5: 2a8290e267e1e1bf9d2ef01f1c8b6be4
+    sha256: b0f72dc82e1f4ed5a223976f9c4368cbc62b729fba7dcb6bfae24be183da61aa
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.11.0-py313h6688731_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.12.0-py313h6688731_0.conda
   hash:
-    md5: 2952fb0d154a199f0ce6c752e4e223b6
-    sha256: 28a5b244c0e43339efa3e61e989c3aceb0136483dfbffbd8991366bc24f42f54
+    md5: 0b812d375a3c4e9e9ca99de4f5e5d446
+    sha256: 2cc5cd7f610b1a38ed9dd5d0f2a06f3ea03c6f4ea3d91318167ade3bd1410de4
   category: main
   optional: false
 - name: python-tzdata
@@ -10700,7 +10827,7 @@ package:
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -10709,14 +10836,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10725,10 +10852,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: quarto
@@ -11065,7 +11192,7 @@ package:
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -11073,42 +11200,42 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.5.1-py313hafbe609_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py313hafbe609_0.conda
   hash:
-    md5: 335b86e1a00e5edd05c5172ddc524919
-    sha256: fc1d2e35b98f8a593d9abbefbbc5d71de1ef9bfa1dfdc9039ae7ef8922ced763
+    md5: 0ff19d7aef2cd2f61cf12838c3138a2e
+    sha256: 42f2aec0823d8493682a18993912d725a108b5a27a606ad5cf7b41ac307b9575
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.5.1-py313hb9d2816_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py313hb9d2816_0.conda
   hash:
-    md5: 8ca4cf4ffd3d47310b389cb8fe096197
-    sha256: c467f6202af51ca5331b2a75987f82846b6db1e3be7686c0bcfb091330724072
+    md5: 78cfb04c5e8beba6273e384643839e44
+    sha256: 5e35d116e8c9582f4cddc930b6d0af8e15bc704090efa3f68ca4b64f7367dbc1
   category: main
   optional: false
 - name: s2n
-  version: 1.7.3
+  version: 1.7.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
   hash:
-    md5: f2bd09e21c5844a12e2f5eefcd075555
-    sha256: 150a0a5254e8b15ad737549721c7d13406cd96432f3f446e07073dbd98bb2491
+    md5: a20feedf58ce5441b115cebf284a9a75
+    sha256: de0bb8c7526684c9927cc687d4d07abe09d023a3ec950cfcd61089b495e2e616
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: linux-64
   dependencies:
@@ -11116,14 +11243,14 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11131,10 +11258,10 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: scikit-learn
@@ -11181,7 +11308,7 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -11193,17 +11320,17 @@ package:
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx: '>=14'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
   hash:
-    md5: 4b098461b0b5edff1a9359c25e675cfd
-    sha256: 2ecb1a3d6aacd20e279a72196954bc8de2e83302823f9dd9f8b9b3310d1bf515
+    md5: a32f88181ff9a3451c71be1f17a7c799
+    sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11214,13 +11341,13 @@ package:
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313h52f5312_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
   hash:
-    md5: f441d9cefca60be8589c309e3af2e6d8
-    sha256: b828f5d0f77e890bc5ec8b2a391bf27c01d468a8b83667bf7786e9a6a1ff12e8
+    md5: 110ff05ffef908af95192bb17c4006a0
+    sha256: d1bf4f384b822df098eddf66ac71e407c63148b1fb3b5cf4d536f6ae40269cca
   category: main
   optional: false
 - name: sdkroot_env_osx-arm64
@@ -11881,29 +12008,29 @@ package:
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: stack_data
@@ -12046,7 +12173,7 @@ package:
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12056,15 +12183,15 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12074,11 +12201,11 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tabulate
@@ -12304,29 +12431,29 @@ package:
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: traitlets
@@ -12354,7 +12481,7 @@ package:
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -12363,14 +12490,14 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12379,10 +12506,10 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: types-pyyaml
@@ -12686,27 +12813,27 @@ package:
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: webcolors
@@ -12806,7 +12933,7 @@ package:
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12814,38 +12941,38 @@ package:
     libgcc: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.1-py313h07c4f96_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py313h07c4f96_0.conda
   hash:
-    md5: 5ba52a9fe1509b87de4d18f26d2fe619
-    sha256: 852d62cce1d7d6ad60fbfbc4ae40981eebbde5f8b68695157d1c96c3ed8f59c3
+    md5: d6f92eb04d026a9e5b9c5d52c8cd65d6
+    sha256: 234b4888d4303c29f839408345f52194078716a369680920af09f6a8fef803a9
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.1-py313h0997733_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py313h0997733_0.conda
   hash:
-    md5: 6fc1287399a77a61f4ae182ccdd692fd
-    sha256: 87680be2386d1e7ec183a58981d8ca0e9e4319ec80e1cc76abb8eaf6429370af
+    md5: 8446508b88050b1a78d5b575de80518b
+    sha256: 1b9bb35df4119949d36874e8e753d0f61a0f6f235deea43818e97af8bf6da768
   category: main
   optional: false
 - name: xkeyboard-config
-  version: '2.47'
+  version: '2.48'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
   hash:
-    md5: b56e0c8432b56decafae7e78c5f29ba5
-    sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
+    md5: b233b41be0bf210989d57160ed39b394
+    sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
   category: main
   optional: false
 - name: xorg-libice

--- a/.github/conda-lock/py3.14.conda-lock.yml
+++ b/.github/conda-lock/py3.14.conda-lock.yml
@@ -13,8 +13,8 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: f4a421eeba6ada63037329f9359ce5046ca1f875af2ae599c1086463be639932
-    osx-arm64: 90be708b018096df704210daf1cf7ac407d830352f4e64becc3fadfb2c87fac3
+    linux-64: 68d271cf59eac34a65391590675f1fdb2ce572093cd78f4b50a13480647a11b3
+    osx-arm64: 84d74a0f4b92ee0189f64233c33cad9e391db617af13ce92988dbe78e8d978d9
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -178,7 +178,7 @@ package:
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -186,14 +186,14 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: anyio
-  version: 4.13.0
+  version: 4.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -201,10 +201,10 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: af2df4b9108808da3dc76710fe50eae2
-    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: appnope
@@ -336,7 +336,7 @@ package:
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -345,14 +345,14 @@ package:
     cpython: '>=3.10'
     libgcc: '>=14'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.5.0-py310hd8a072f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.6.0-py310hd8a072f_0.conda
   hash:
-    md5: 6adea4814147f458d6278d053850b0ac
-    sha256: cf1cf3d0fa59fe0ab6bc3af722d820c1a85a9233c786f614f377c651fec6a7f9
+    md5: 530aaeffb462b062bf8e3abb66879cf0
+    sha256: 98eef90c96e2185254d12e667337077b989e9892167ff2c969e19b9296f42743
   category: main
   optional: false
 - name: ast-serialize
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -360,10 +360,10 @@ package:
     _python_abi3_support: 1.*
     cpython: '>=3.10'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.5.0-py310h3b8a9b8_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.6.0-py310h3b8a9b8_0.conda
   hash:
-    md5: 480f5277fd3ed13ea6ea8b5d74563815
-    sha256: 6c6e47ef2a85e7ade5c94d2388f43bd8197129e6b6305f9e8a49380b7dfbc427
+    md5: 9bc9209a773faadbdca5fe45d9aa9cdc
+    sha256: 0efbe4158ee4d5ff4108ad1b8c677e85eb1a8f3bb48fe2277579860d38e48315
   category: main
   optional: false
 - name: astroid
@@ -393,66 +393,66 @@ package:
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
     libgcc: '>=14'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-7.2.0-py314hc02f841_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-base-8.0.0-py314hc02f841_0.conda
   hash:
-    md5: 8c7d00a0b82d5399c242be5c80a5a0d4
-    sha256: c430dec69f18dd013fb8d7a930cb1f4b3781ba0d150bb18dc3a221eaeca57ca8
+    md5: 290ad6a8e32cb57bc853ab5351c03f74
+    sha256: 99e785ac0d8ad0906ea7f47de88ade9404f0c364d58c2667d410e476505dce53
   category: main
   optional: false
 - name: astropy-base
-  version: 7.2.0
+  version: 8.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    astropy-iers-data: '>=0.2025.10.27.0.39.10'
-    numpy: '>=1.24'
-    packaging: '>=22.0.0'
-    pyerfa: '>=2.0.1.1'
+    astropy-iers-data: '>=0.2026.6.1.17.39.59'
+    numpy: '>=2.0'
+    packaging: '>=25.0'
+    pyerfa: '>=2.0.1.3'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
     pyyaml: '>=6.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-7.2.0-py314hdcf55e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/astropy-base-8.0.0-py314h2115a04_0.conda
   hash:
-    md5: 59d305b4aac5f4b79d5c8a5c9383f6fe
-    sha256: bbc0210239ef80bd80e5981b192f03c5a237a9a066945025585234648db19d11
+    md5: 968f94b4abb254a1efac5f0bde3dc780
+    sha256: 9a1187a78941f4a3f89583ed1b01854e199f9f1f2f93730183e06368e9b5f6e3
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2026.6.8.17.49.5
+  version: 0.2026.6.22.1.23.34
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.8.17.49.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2026.6.22.1.23.34-pyhd8ed1ab_0.conda
   hash:
-    md5: a1c040b1c7f3b10ca929f4118ad1f732
-    sha256: 936ea04f49059569d7cea4e51d3213898652478ca9f4f3d30701c0f6aa3860f1
+    md5: 0b69dd5a6b6c2ad0690fd231fb5cb9e5
+    sha256: 62fec5e639c0ba9fcfc633175b602881055a3e90a8ca2172c8f7aa4c541cee9d
   category: main
   optional: false
 - name: asttokens
@@ -601,12 +601,12 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
   hash:
-    md5: c463d2dbfb12a208c943165d2a568db4
-    sha256: 5b9c20a38fe084b4ffd1f2c64b3797ec6ef9a99e83cc0c1f84e016c9801e3a5c
+    md5: 9329dcd00c4d61aa49e516dddd784e91
+    sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
   category: main
   optional: false
 - name: aws-c-auth
@@ -619,11 +619,11 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
   hash:
-    md5: e7501df14d3145fc86943ebfeb76a402
-    sha256: b4689664156e8067ba1aa97125f2a309a96b2bc0d1c608f4a88f30ea1f4c9aba
+    md5: 1fc365a60432d78b729d1468fce1b6c9
+    sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
   category: main
   optional: false
 - name: aws-c-cal
@@ -748,11 +748,11 @@ package:
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-    s2n: '>=1.7.3,<1.7.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h5b668fc_4.conda
+    s2n: '>=1.7.4,<1.7.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
   hash:
-    md5: 555400dce62f2d989ff77761c010d166
-    sha256: c27b972325342f062da00b7aa2d5abf6f3ce55668a05703a175be958745cc226
+    md5: 12697e83c2a0e5b93fd03855a70eb360
+    sha256: c798005b65bc74d02aba1db01d4d344c4e72662f0beef35fbdd35b4695c197de
   category: main
   optional: false
 - name: aws-c-io
@@ -763,14 +763,14 @@ package:
     __osx: '>=11.0'
     aws-c-cal: '>=0.9.14,<0.9.15.0a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
   hash:
-    md5: b33f51eca94f6ccbd772ca4043fe1718
-    sha256: 18f51bdc45eabe01ca68edf5ccc73369b3201639790575e6776f3efaea6e4356
+    md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
+    sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -782,15 +782,15 @@ package:
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
   hash:
-    md5: 70bc8e5e8cefd19407423733e7ebf540
-    sha256: 8f193173f1dccb25ff86a95543db27f0c762cccfe93157b02cf20bd5b4c11a92
+    md5: f2b6275244daa12109bcd0a126f1fb85
+    sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -801,37 +801,37 @@ package:
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
   hash:
-    md5: 7dc63973f9fe772985b8c2f8ba5958ce
-    sha256: 0a99b506bbe21f00f21047db50b2eea2ff8a0b1146ff0fba7d04b39a568453f4
+    md5: 912c61c44a2782693d63af2272551455
+    sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
   hash:
-    md5: 4b66ac29a7e917a629b790c3d239d110
-    sha256: 123c4325b16f1f6db95846d51e5e4201399ee29c0325f8b5a8db2e7d732b9151
+    md5: 5088795f3dfcf00a26f03c2a17ae8429
+    sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
   hash:
-    md5: 127bce41f9e6cc3bdb9e6daed95896d9
-    sha256: ef53cd1e30bc8c865c44df6f097f36361945665157e63957d68fe90aa7e4d66c
+    md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
+    sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
   category: main
   optional: false
 - name: aws-checksums
@@ -886,27 +886,27 @@ package:
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.14'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.5.0-py314h680f03e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
   hash:
-    md5: 1133126d840e75287d83947be3fc3e71
-    sha256: a1c97297e867776760489537bc5ae36fa83a154be30e3b79385a39ca4cb058fe
+    md5: 40d89d8546ad6e139e73ec8f6d56068b
+    sha256: 709cac7434d1c5a8828105036212a2a36022a07d807e89e2e99cac939c2d2526
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.14'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.5.0-py314h680f03e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
   hash:
-    md5: 1133126d840e75287d83947be3fc3e71
-    sha256: a1c97297e867776760489537bc5ae36fa83a154be30e3b79385a39ca4cb058fe
+    md5: 40d89d8546ad6e139e73ec8f6d56068b
+    sha256: 709cac7434d1c5a8828105036212a2a36022a07d807e89e2e99cac939c2d2526
   category: main
   optional: false
 - name: beautifulsoup4
@@ -1240,7 +1240,7 @@ package:
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -1250,14 +1250,14 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.3-hc31b594_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.1.5-hc31b594_0.conda
   hash:
-    md5: 2f0eb57a686a4e27719ce0b0076784a1
-    sha256: 4029fb93e133c0de986464c2f1b02630f141f976cb25b5b929994b34a2a51bf5
+    md5: 76ea4a0e8f1600f89cbb2d3d62ac2b04
+    sha256: 6e42591b70252b4e91a3391894c570e45d7f1f21b20937c8f57f16e3cf659e5d
   category: main
   optional: false
 - name: c-blosc2
-  version: 3.1.3
+  version: 3.1.5
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1266,10 +1266,10 @@ package:
     lz4-c: '>=1.10.0,<1.11.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.3-hf9886e1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.1.5-hf9886e1_0.conda
   hash:
-    md5: 8cbeea5e4377be5f486b94ee658590a9
-    sha256: 828449a87f57b4ccb793f1db645cf9d5a816186d978de6df31b053a57b248204
+    md5: c70b84faedf42fe923b584a587159081
+    sha256: a2db3ad1b7fedc40b3436d5382415bb63faac2baf69142c369f6040b71aeb8be
   category: main
   optional: false
 - name: c-compiler
@@ -1302,27 +1302,27 @@ package:
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   hash:
-    md5: 489b8e97e666c93f68fdb35c3c9b957f
-    sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+    md5: a9965dd99f683c5f444428f896635716
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   category: main
   optional: false
 - name: cached-property
@@ -1517,27 +1517,27 @@ package:
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: certifi
-  version: 2026.5.20
+  version: 2026.6.17
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fefff2f745ea1cc2ef15211a20c054a
-    sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+    md5: c13824fedced67005d3832c152fe9c2f
+    sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
   category: main
   optional: false
 - name: cffi
@@ -2083,7 +2083,7 @@ package:
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -2092,14 +2092,14 @@ package:
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.1-py314h67df5f8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.3-py314h67df5f8_0.conda
   hash:
-    md5: 2af0e1fec00680b1b6ef3859585ca8fa
-    sha256: 4fb298517c0aff45eb449bf4bd484c0f4d0ab36d4e5c1005b7f0312e68330b57
+    md5: e3aecdc8eab8a93c5aad5f113fa91509
+    sha256: 68f6814d548e6b1d8b655371cb34b909f5862d5d80b4b6ccf7231a84ceeb88da
   category: main
   optional: false
 - name: coverage
-  version: 7.14.1
+  version: 7.14.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2107,36 +2107,36 @@ package:
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.1-py314h6e9b3f0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.3-py314h6e9b3f0_0.conda
   hash:
-    md5: 75074919bec101f674e64b0c00a8aa7c
-    sha256: b2c5285cf2610bf98d0df3c1474beb2e706d2d75b2ae4b1cd7f7f22ef6932c3a
+    md5: cb60422148fa8d70cbb6fc290e79e21c
+    sha256: 8de3938e100bbbd775d3b0c6d121c29e7aa2cd0024a9b5ee8023706c0b8f28e6
   category: main
   optional: false
 - name: cpython
-  version: 3.14.5
+  version: 3.14.6
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.14,<3.15.0a0'
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.5-py314hd8ed1ab_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
   hash:
-    md5: a749029ce5d0632a913db19d17f944ab
-    sha256: 777882d2685f368417f31bbe1b28f73687fc6c8f6a5768bda20ffeefa6b07f5b
+    md5: b28fe35fd43d5f425c0dccbe5b5039fd
+    sha256: 7a548856ef5307890a8cadfc196655117658f8c24589ce175caa4c1c2ded9d13
   category: main
   optional: false
 - name: cpython
-  version: 3.14.5
+  version: 3.14.6
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.14,<3.15.0a0'
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.5-py314hd8ed1ab_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
   hash:
-    md5: a749029ce5d0632a913db19d17f944ab
-    sha256: 777882d2685f368417f31bbe1b28f73687fc6c8f6a5768bda20ffeefa6b07f5b
+    md5: b28fe35fd43d5f425c0dccbe5b5039fd
+    sha256: 7a548856ef5307890a8cadfc196655117658f8c24589ce175caa4c1c2ded9d13
   category: main
   optional: false
 - name: cxx-compiler
@@ -2191,7 +2191,7 @@ package:
   category: main
   optional: false
 - name: cython
-  version: 3.2.5
+  version: 3.2.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -2200,14 +2200,14 @@ package:
     libstdcxx: '>=14'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.5-py314h1807b08_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.2.8-py314h1807b08_0.conda
   hash:
-    md5: f7c56f4cda343c502ce74a31289a82af
-    sha256: 5fb945e34813beab47d343fd14945b641ed196f95f2e1896b6e485e9d27803db
+    md5: 0e6a14f60b561b2fff81d325b4dc8283
+    sha256: f0210259007f573e38f7b8037be9b36e53aa0906b786e9f1f931e0a24f8a18e6
   category: main
   optional: false
 - name: cython
-  version: 3.2.4
+  version: 3.2.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2215,32 +2215,32 @@ package:
     libcxx: '>=19'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.4-py314hc6117b3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.2.8-py314h65f46a9_0.conda
   hash:
-    md5: 1289de88f884ac89144949cb97ccabe7
-    sha256: 3e8673f712f8a28ca89fe728f71fdeb81e971b91683fa7154746bd3e23f7bd1b
+    md5: 79d369d7b561c5fc83ca6e911227d937
+    sha256: 3da78a29c8a1998004d52416957d48947bc0b6c4e6b26cf1a17a227b9ec4710d
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.100.0-hfc2019e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.101.0-hfc2019e_0.conda
   hash:
-    md5: 97b46522187a0064a52207a3ca68621c
-    sha256: 43146af49e6911c7bc57eedfdb945cb3ecbaa73e9565e84099229345edebe0c5
+    md5: 3c5956f8de352968510d857a1dfdf929
+    sha256: 624d4599a0b72315473a8854a4abbafc4e2a774b2bd8e64788823a798546321c
   category: main
   optional: false
 - name: dart-sass
-  version: 1.100.0
+  version: 1.101.0
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.100.0-h820172f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.101.0-h820172f_0.conda
   hash:
-    md5: 2ae10fcbebb03cae94eefc1ec6311956
-    sha256: c4595381f35451b995af233fd4fe40aa4e56497d8d5d4110250f71df0e71003a
+    md5: 0271842f65ca34de8326cf8dbd38dda8
+    sha256: cafab0396ee8c6e24c0401d71be1669852a03e11cf130cf394b65382fe88ae7f
   category: main
   optional: false
 - name: dbus
@@ -2648,25 +2648,25 @@ package:
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.0-hfc2019e_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.28.1-hfc2019e_0.conda
   hash:
-    md5: 436dd09d9b9e59414bf803453795c5b5
-    sha256: e06f972eee640fe5ece7931e97bf9d317589fa9798ad19fa5c8761a7e393ace7
+    md5: 65b5461adebff76dc54e02c5c19a20a8
+    sha256: 2ff0603150014c840474d0ddc8813569d91f9ab20e83cb49b1019eb4155c0a63
   category: main
   optional: false
 - name: esbuild
-  version: 0.28.0
+  version: 0.28.1
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.0-hf76c51c_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/esbuild-0.28.1-hf76c51c_0.conda
   hash:
-    md5: 8d9633a86fd47d9244f14f98f1d5c094
-    sha256: 73a69d92e36d9f6889ed080fc1e3cbe3ac94c9e5d6b3683c1792acf0fd86f043
+    md5: 7023b247571c6428ac7752c87193d68d
+    sha256: 340c65b3acdbe58b815b363304f93a25dd5cfd96bc0479b24f3d656b71522853
   category: main
   optional: false
 - name: exceptiongroup
@@ -3370,46 +3370,46 @@ package:
     binutils_linux-64: ''
     gcc_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
   hash:
-    md5: c75730101e8fcefeb3867aa52954bf76
-    sha256: 1a1736aaa63271c782cbe79353560f272cc889447bcab6000201e924eb9a6a27
+    md5: 90369fa27fae2f7bf7eaaccc34c793e2
+    sha256: d7f427d6db94a5eed2a43b186f8dc17cc1fbeb03517442390a36f1cde02548b0
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libglib: '>=2.88.2,<3.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.7-h2b0a6b4_0.conda
   hash:
-    md5: 7892f39a39ed39591a89a28eba03e987
-    sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
+    md5: 5d355db3e937086e22cf4cb5fe19787c
+    sha256: 1c22e37f9d7e06e9e0582ee5a55c2ddd19ea75f71f44eb13b56f504ef5c37aa5
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.6
+  version: 2.44.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.2,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.56,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.6-h4e57454_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.7-h4e57454_0.conda
   hash:
-    md5: e67ebd2f639f46e52af8531622fa6051
-    sha256: 07cbba4e12430de35ea608eb3006cf1f7f63832c4f89a081cd6f3872944c1aa6
+    md5: f717a22e13a1499c9552ffff02d22d64
+    sha256: 69bb2e62a93f6407c9e9ccd4d21fe4d4e5373d64eecd6c5df318144ca4c80953
   category: main
   optional: false
 - name: getdist
@@ -3550,10 +3550,10 @@ package:
     gcc_linux-64: ==14.3.0
     gfortran_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-hd59e7da_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-h5ce6d8a_27.conda
   hash:
-    md5: 2ff2d83810d91869f20abb7e28c4d7da
-    sha256: 2e140d31ecbc74c44ab03e3fd40f51af2a0861ad399526205801bc0cd3ff5061
+    md5: cedd6fb9fad7611ee0bcb0fb531d77f1
+    sha256: b8e6bd99f0b7a5e8757a1cf9bf64edc6217206d8872fb9af5d8204e5b581b3d1
   category: main
   optional: false
 - name: gfortran_osx-arm64
@@ -3616,65 +3616,65 @@ package:
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.1-hd810c12_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.2-hbe0478d_0.conda
   hash:
-    md5: 9add1716591862a115c885dda4fcbeb5
-    sha256: 6a97b61cfb30a85c2f4a95f1f7525a873eea0b540f9f11b9cf31ad70d6635fce
+    md5: 7ac6295be13fafd7f20869b30b47ec2f
+    sha256: 84448dc33e66a2c74c58fb2a95d9e84547bc65cf44dcebf447b8d236c0ccc68b
   category: main
   optional: false
 - name: glib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    glib-tools: ==2.88.1
-    libglib: ==2.88.1
+    glib-tools: ==2.88.2
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
     libintl-devel: ''
     packaging: ''
     python: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.1-h92d5a4f_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.88.2-h2792883_0.conda
   hash:
-    md5: 937bab93d8e05d664f45f1aed40291ba
-    sha256: e6804164a3d771d369d97fd08a2db739321d452c9ffa6803f9bbf309aa1f4dfe
+    md5: a53abd3898d5addc45f164e8c5dbef50
+    sha256: 74b4c85756d2584abf3972035a3d68edd5b723527460a261b6df21bfe6980f7e
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libffi: ''
     libgcc: '>=14'
-    libglib: ==2.88.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda
+    libglib: ==2.88.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.2-h8094192_0.conda
   hash:
-    md5: e5a459d2bb98edb88de5a44bfad66b9d
-    sha256: ae41fd5c867bc4e713a8cc1dc06f5b418026fec116cc222abe33e94235c6b241
+    md5: cfe66c21ae651b84a3d25a1dbb641a54
+    sha256: 079757e4e0497d67505b52062668e4cc0d2a86ec065ae2c0c57487a178206061
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libffi: ''
-    libglib: ==2.88.1
+    libglib: ==2.88.2
     libintl: '>=0.25.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.1-h37541a8_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.2-h246a70f_0.conda
   hash:
-    md5: 8d4580a91948a6c3383a7c2fbfe5311c
-    sha256: 414bdf86a8096d5706293d163359def2e61b8ffd3fe106bbf2028d79e58e6a97
+    md5: 973a5ef252899cd0916418c75a864169
+    sha256: 6a98eabd4d5bb902c391e9f7c9e655ce61292ff6f1bb0c592da42fd66e6c89f9
   category: main
   optional: false
 - name: gmp
@@ -4022,10 +4022,10 @@ package:
     gcc_linux-64: ==14.3.0
     gxx_impl_linux-64: 14.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h175a97f_26.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
   hash:
-    md5: 1bfdaeeea0b3d0031d9ad755296afbce
-    sha256: 89d8a3268bafb3f80e95ab9a4a062f332b11be836789cebd9ec490ccf3eb7428
+    md5: 41fae38a424bbc78438cfec6a4fde187
+    sha256: cf5a44d14732b79e3c2bc6ebe1dba4f6b9077939f3093c75e36ad340737b5c15
   category: main
   optional: false
 - name: h11
@@ -4122,21 +4122,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libglib: '>=2.88.1,<3.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
   hash:
-    md5: 21ee4640b7c2d94e584349fa12b29b9a
-    sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
+    md5: 72e956a71241633d8c80aa198fd08784
+    sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
   category: main
   optional: false
 - name: harfbuzz
@@ -4144,20 +4134,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libcxx: '>=19'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libglib: '>=2.88.1,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
+    libharfbuzz-devel: 14.2.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-hce30654_1.conda
   hash:
-    md5: 389b1c7cb4738fa74f8a142336807a13
-    sha256: 5593f4aad6580707eb268e8dbb4c562a736d87bea03f5e1551becaebfe1a6620
+    md5: 95896299aa1012c7410629b2ee360f87
+    sha256: 8922ec1cd17f558ca38c513d4880b7fadbfa08b38a563880c8c2ceddfcc1fba2
   category: main
   optional: false
 - name: hdf5
@@ -4170,8 +4151,8 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
@@ -4179,11 +4160,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
   hash:
-    md5: b1b444bca8da3ff6cc4afad1fa7f7d61
-    sha256: ff8336394dcfaccf49e56d1dd66091cf767df0d3d33f3fa440c980e0445b34cc
+    md5: 3c126667b98ad8ccf390a91b9097f574
+    sha256: 8225145aababbef3f8900b651cfa4ac9257cd4d522957711f469f6ea5b504761
   category: main
   optional: false
 - name: hdf5
@@ -4196,19 +4177,19 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
   hash:
-    md5: fb804a23360d2b40c4f9d15a8bf0b869
-    sha256: 67e9ef0dfd22a37ff51d0b19aa35e9f7da21739a624976bcac1f72ab1698e8f8
+    md5: 5cc8ba7775f6694349b7a71837bbad90
+    sha256: 8f37c0185801b81a50e4e1430501ddd1c9bfe5e6a5e4ea3c61464e0f1d9199aa
   category: main
   optional: false
 - name: healpy
@@ -4281,27 +4262,27 @@ package:
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: httpcore
@@ -4395,7 +4376,7 @@ package:
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -4405,14 +4386,14 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: hypothesis
-  version: 6.155.2
+  version: 6.155.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4422,10 +4403,10 @@ package:
     python: '>=3.10'
     setuptools: ''
     sortedcontainers: '>=2.1.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
   hash:
-    md5: 211e13260293e6b4b3841dba94921558
-    sha256: ba55c0dce7aa063fe9bf00dcdb2caa4a25be0aced5fe8527a63dfccfd525dbaa
+    md5: 699483c625c9ed7e43b766777ea3721d
+    sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
   category: main
   optional: false
 - name: icu
@@ -4455,27 +4436,27 @@ package:
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: idna
-  version: '3.17'
+  version: '3.18'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
-    md5: c75e517ebd7a5c5272fe111e8b162228
-    sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+    md5: 577b04680ae422adb86fc60d7b940659
+    sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
   category: main
   optional: false
 - name: imagesize
@@ -4526,32 +4507,6 @@ package:
   hash:
     md5: ffc17e785d64e12fc311af9184221839
     sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ba6225c279baf7ea9473a62ea0ec9ae
-    sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
   category: main
   optional: false
 - name: iniconfig
@@ -4630,7 +4585,7 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4647,14 +4602,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4671,10 +4626,10 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: main
   optional: false
 - name: ipython_pygments_lexers
@@ -4802,29 +4757,29 @@ package:
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: main
   optional: false
 - name: jinja2
@@ -4880,27 +4835,27 @@ package:
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: json5
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1269891272187518a0a75c286f7d0bbf
-    sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
+    md5: 761a4a6b9cba303c66a97ca642447171
+    sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
   category: main
   optional: false
 - name: jsonpointer
@@ -5061,6 +5016,36 @@ package:
   hash:
     md5: 9453512288d20847de4356327d0e1282
     sha256: b538e15067d05768d1c0532a6d9b0625922a1cce751dd6a2af04f7233a1a70e9
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
+  category: main
+  optional: false
+- name: jupyter-builder
+  version: 1.0.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    jupyter_core: ''
+    python: ''
+    tomli: ''
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  hash:
+    md5: 12b0a9513f6abaa944c313c4a01d5500
+    sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
   category: main
   optional: false
 - name: jupyter-lsp
@@ -5238,7 +5223,7 @@ package:
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5261,14 +5246,14 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.19.0
+  version: 2.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5291,10 +5276,10 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.19.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 82525f37e0976e83bbb69bc4d4011665
-    sha256: 896a350a026db8fff26a7884ed841d53cb84f57f914064fbead0628ab23d1da0
+    md5: b2ddb0e13b5600070c4019c4db8a78e6
+    sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
   category: main
   optional: false
 - name: jupyter_server_terminals
@@ -5324,7 +5309,7 @@ package:
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -5332,25 +5317,25 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab
-  version: 4.5.8
+  version: 4.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5358,21 +5343,21 @@ package:
     httpx: '>=0.25.0,<1'
     ipykernel: '>=6.5.0,!=6.30.0'
     jinja2: '>=3.0.3'
+    jupyter-builder: '>=1.0.2'
     jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
+    jupyter_server: '>=2.19.0,<3'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2'
     packaging: '>=23.2'
     python: '>=3.10'
-    setuptools: '>=41.1.0'
     tomli: '>=1.2.2'
     tornado: '>=6.2.0'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.5.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e3f969b0c5d9c22191f3c3306c0f1fb
-    sha256: 46565306e181df07cd5aed855fa7ef3522658e11b3a840ebbf047ea675c51d30
+    md5: 7ba07211c94d434f3223a4418f8b1ff8
+    sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
   category: main
   optional: false
 - name: jupyterlab_pygments
@@ -5528,11 +5513,11 @@ package:
     libedit: '>=3.1.20250104,<4.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
   hash:
-    md5: fb53fb07ce46a575c5d004bbc96032c2
-    sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
   category: main
   optional: false
 - name: krb5
@@ -5543,11 +5528,11 @@ package:
     __osx: '>=11.0'
     libcxx: '>=19'
     libedit: '>=3.1.20250104,<4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
   hash:
-    md5: e446e1822f4da8e5080a9de93474184d
-    sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+    md5: 8780f41b013d19219faef9c82260744b
+    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
   category: main
   optional: false
 - name: lark
@@ -5903,7 +5888,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5911,44 +5896,46 @@ package:
     krb5: '>=1.22.2,<1.23.0a0'
     libgcc: '>=14'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
   hash:
-    md5: c3cc2864f82a944bc90a7beb4d3b0e88
-    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+    md5: f9c59d277a16ec8f272b2d5dd2ec3335
+    sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     krb5: '>=1.22.2,<1.23.0a0'
     libnghttp2: '>=1.68.1,<2.0a0'
+    libpsl: '>=0.22.0,<0.23.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h1359186_2.conda
   hash:
-    md5: 2f57b7d0c6adda88957586b7afd78438
-    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+    md5: dfe89fb0539ad4611998a5c6905692ff
+    sha256: b21aec36796a7d9b3c8b634f2d466c1d0a2658b2e57aa4686285cf4c10d5c227
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
   hash:
-    md5: 0325fbe13eb6dd39234eb305ac1b3cb8
-    sha256: cceb668dc1b71f054b1036dd83eca2e02c0c3a4b2ba3ad28c74a982d819597a3
+    md5: 89f76a2a21a3ec3ec983b5eb237c4113
+    sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
   category: main
   optional: false
 - name: libcxx-devel
@@ -6132,31 +6119,31 @@ package:
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
   hash:
-    md5: 0b82ff1ab3db9122f20cafe93f61bc3b
-    sha256: c2b53beed03c735b18116d5227410b15cc9fbef209795212afd179f8c8a5fd70
+    md5: b04e60c49d09399a009f3bb70bb53a23
+    sha256: 45bb0eb92000a3f82555cc948013935aace8a1ea522b79700f58d3906c18e846
   category: main
   optional: false
 - name: libfabric
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.5.1-hce30654_1.conda
+    libfabric1: 2.6.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
   hash:
-    md5: fbd3f6f592ca4d3c404c303c1c5d89bd
-    sha256: e792acfdeb39c508640f5558ef79d190c88c589edc1e00605a44159af0cadf34
+    md5: b92a04dd36f41b0d8dfed62ff7812eea
+    sha256: 048eb6e03202b5a6f8ecbcdeb5a3f5ac9702736aa494de6615639d60ff68adc9
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -6164,22 +6151,22 @@ package:
     libgcc: '>=14'
     libnl: '>=3.11.0,<4.0a0'
     rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
   hash:
-    md5: 4a7168d686b6125ba546134dddb16721
-    sha256: f64b69e48636871081fde0604ed37fac32a7146073ad2899550bcc0b14e7c09d
+    md5: 7d8c510157360d0a6fdd84a1d3db8de7
+    sha256: ba8de6a838bc0727ef8e5a1409c6735465b7b582627a9b4c2704126e53903f43
   category: main
   optional: false
 - name: libfabric1
-  version: 2.5.1
+  version: 2.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.5.1-h84a0fba_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
   hash:
-    md5: 7e0759abab6964339520b84d0990c07a
-    sha256: 071a14074dbf7f7be2fb52798638e9a8194324bcb8deab50b452cc099729ea1c
+    md5: 5b0d1d64a7fe7e86900dd1859d2dd4d4
+    sha256: 267ab5fe990209b33de220432bcb595a88e6bb642e282bbe433a8edfdc811c1a
   category: main
   optional: false
 - name: libffi
@@ -6533,7 +6520,7 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -6543,14 +6530,14 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
   hash:
-    md5: 17d484ab9c8179c6a6e5b7dbb5065afc
-    sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
+    md5: 889febc66cd9e4190f80ef9718fa239b
+    sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
   category: main
   optional: false
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6560,10 +6547,10 @@ package:
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.2-ha08bb59_0.conda
   hash:
-    md5: 62d6f3b832d7d79ae0c0aa1bb3c325fa
-    sha256: 3b32a7a710132d509f2ea38b2f0384414c863533e0fc7ac71b6a0763e4c67424
+    md5: 03123cafdc96cef79fc8a615f9119b79
+    sha256: 68ac66904a284a7dfbb3bdf9225380eaf20750b2d414215e6d7af5caa3ed1a63
   category: main
   optional: false
 - name: libglvnd
@@ -6617,6 +6604,96 @@ package:
   hash:
     md5: faac990cb7aedc7f3a2224f2c9b0c26c
     sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+  hash:
+    md5: fb4669c3990b94ea32fbb81f433e9aa6
+    sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e8d6e86663316dfbdec7dac532824516
+    sha256: 75860db66af9748572038d1e3a2260eca56ee4b38b9523e042fac8caf4277529
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+  hash:
+    md5: 99cf21100441e51272f1cd6fe0632a20
+    sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+  category: main
+  optional: false
+- name: libharfbuzz-devel
+  version: 14.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.4,<2.0a0'
+    freetype: ''
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: 14.2.1
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-devel-14.2.1-h5a65909_1.conda
+  hash:
+    md5: e538f961a3042abf8307c5c5a6d6b09b
+    sha256: f3f74f090b6a31fed00d64cbe6bbeed6b2a9b820442714ecb66ada08dec913ea
   category: main
   optional: false
 - name: libhwloc
@@ -6952,6 +7029,68 @@ package:
     sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   category: main
   optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hd9031aa_0.conda
+  hash:
+    md5: e2834a423b3967e7b3b1e901c4a5f42f
+    sha256: cd11890a2c1f14d0342bfcbd81f97152d61dc71c27c7085efc13705a8f64f7c9
+  category: main
+  optional: false
+- name: libpsl
+  version: 0.22.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-hb427e8f_0.conda
+  hash:
+    md5: 39234f5550649043b04b3d73a2017f81
+    sha256: c14b5b584dc349df5ff5f6fa114d522090a0488fcb1599df0881fd53af45010c
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=14'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.10.5-h6406941_1.conda
+  hash:
+    md5: fa63517815747363c41b439ff9301db1
+    sha256: 7c9e562842f193f772ef0ba681f238a2d9e5ef637588b6e46eb30cc6aa1940c8
+  category: main
+  optional: false
+- name: libraqm
+  version: 0.10.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    fribidi: '>=1.0.16,<2.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libharfbuzz: '>=14.2.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libraqm-0.10.5-h45af499_1.conda
+  hash:
+    md5: fa1a27aaaa10e92be48372fa01573f7c
+    sha256: 7d88c506b9899d60e57f7456b02f54c7330029f2ad56c6df96357f981aa1bd96
+  category: main
+  optional: false
 - name: librsvg
   version: 2.62.3
   manager: conda
@@ -7046,31 +7185,30 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
   hash:
-    md5: 062b0ac602fb0adf250e3dfa86f221c4
-    sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+    md5: 4aed8e657e9ff156bdbe849b4df44389
+    sha256: 365376f4815e5e80def2b3462a2419708b7c292da0da85278386c2618621fff4
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.2
+  version: 3.53.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.3-h1b79a29_0.conda
   hash:
-    md5: 1ebde5c677f00765233a17e278571177
-    sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+    md5: 7184d95871a58b8258a8ea124ed5aabc
+    sha256: a73a8acd97a6599fd6e561514db9f101ca7fd984cdc0cfd91ba74c8aa9dbe067
   category: main
   optional: false
 - name: libssh2
@@ -7208,16 +7346,16 @@ package:
   category: main
   optional: false
 - name: libuuid
-  version: 2.42.1
+  version: 2.42.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
   hash:
-    md5: 7d0a66598195ef00b6efc55aefc7453b
-    sha256: 3f0edf1280e2f6684a986f821eaa3e123d2694a00b31b96ca0d4a4c12c129231
+    md5: 01bb81d12c957de066ea7362007df642
+    sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
   category: main
   optional: false
 - name: libwebp-base
@@ -7430,15 +7568,15 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.7
+  version: 22.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.7-hc7d1edf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
   hash:
-    md5: 7c6a5897a8bc5b6d509a4ee9dec7fcc8
-    sha256: 6bf27376f11198c01a88a1c8234470f45bce0aa7502b7e7988ef03ef5db3a890
+    md5: a9c118f6343fb6301b6f3b4e94c4c562
+    sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
   category: main
   optional: false
 - name: llvm-tools
@@ -7611,7 +7749,7 @@ package:
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7624,8 +7762,9 @@ package:
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
+    libraqm: '>=0.10.5,<0.11.0a0'
     libstdcxx: '>=14'
-    numpy: '>=1.23,<3'
+    numpy: '>=1.25,<3'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -7634,14 +7773,14 @@ package:
     python_abi: 3.14.*
     qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py314h1194b4b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py314had63eae_1.conda
   hash:
-    md5: 11a821746ad11e642fcc615c3d66aa44
-    sha256: 94599b0ca937530f7c7ba1e394cbe8420db613da2524bd0000988e9bbe118f0a
+    md5: 5866f3034ce42e8d512e7640f43270fd
+    sha256: 666a19f61a40c5936bd0f07965b159ced727256fa7e2a4ff9dd5f0146aad86f1
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.9
+  version: 3.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7654,7 +7793,8 @@ package:
     libcxx: '>=19'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    numpy: '>=1.23,<3'
+    libraqm: '>=0.10.5,<0.11.0a0'
+    numpy: '>=1.25,<3'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -7662,10 +7802,10 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.14.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py314hc042b31_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.0-py314hf6804ef_1.conda
   hash:
-    md5: 3252e58ac5ade3ba2dacd5dacfa6e7b8
-    sha256: 8c1912582f457a40e39b9770dc2417c804f5ab1eb1ce73860d24a1414fb56145
+    md5: 839648f58bc9c220a496ad342adc34d9
+    sha256: a55f1d61cb9265187477a90dd9d3b4a82a1d559d291846af5f4719815822fff4
   category: main
   optional: false
 - name: matplotlib-inline
@@ -7794,29 +7934,29 @@ package:
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mistune
-  version: 3.2.1
+  version: 3.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: b97e84d1553b4a1c765b87fff83453ad
-    sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: main
   optional: false
 - name: mizani
@@ -8119,27 +8259,27 @@ package:
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: narwhals
-  version: 2.22.1
+  version: 2.23.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
   hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
+    md5: a537eb35988a6f2b1ceda6cce83e2f0e
+    sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
   category: main
   optional: false
 - name: nautilus-sampler
@@ -8386,39 +8526,39 @@ package:
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook
-  version: 7.5.7
+  version: 7.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: '>=5.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.5.8,<4.6'
+    jupyter-builder: '>=1.0.2,<2'
+    jupyter_server: '>=2.19.0,<3'
+    jupyterlab: '>=4.6.0,<4.7'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
     python: ''
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 92b46e8c96039d3d7c4958f426bca753
-    sha256: f4974b9984376f75fe8cabab06b25e23addaa7d962e8a713da3f4a213ded8c7b
+    md5: d9eb17006787e506bcb70f16daf1b1c1
+    sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
   category: main
   optional: false
 - name: notebook-shim
@@ -9078,16 +9218,16 @@ package:
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9096,22 +9236,22 @@ package:
     python_abi: 3.14.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py314h8ec4b1a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py314h8ec4b1a_0.conda
   hash:
-    md5: 76c4757c0ec9d11f969e8eb44899307b
-    sha256: 123d8a7c16c88658b4f29e9f115a047598c941708dade74fbaff373a32dbec5e
+    md5: 233e62a8eb894b79b5c93f4f8dec4dcd
+    sha256: bcab128df8980514061a78b9c67f5004954048f584da20df8c5a78de9e3f5abb
   category: main
   optional: false
 - name: pillow
-  version: 12.2.0
+  version: 12.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxcb: '>=1.17.0,<2.0a0'
@@ -9120,10 +9260,10 @@ package:
     python_abi: 3.14.*
     tk: '>=8.6.13,<8.7.0a0'
     zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py314hab283cf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.3.0-py314hab283cf_0.conda
   hash:
-    md5: adf49537da0e0c34cf735e71fe579506
-    sha256: 3d8a86c8cf69ea4bdfeaa3e89e7218bcdc1522e58c9c6298263bfede8ab48cee
+    md5: 4f25498ea1962ab24097fed8700e91ae
+    sha256: dd7303ea135116cc1182c109825459a9eeb77d244d3899f03dd8d83a8db956f9
   category: main
   optional: false
 - name: pip
@@ -9229,7 +9369,7 @@ package:
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -9240,14 +9380,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: plotnine
-  version: 0.15.5
+  version: 0.15.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9258,10 +9398,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.8.0'
     statsmodels: '>=0.14.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotnine-0.15.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 344824239510135219ab04d98c1dbaf0
-    sha256: 08aaaf8a3d554d9049e8203135119b7710c413e59d1b805fa858d4e84e60d5da
+    md5: e34b54b89007b2111d7b144767944f35
+    sha256: a1753ee451d26fea0dea81b936c1c67ccdd36a9d04a38972b542eb1eadff8510
   category: main
   optional: false
 - name: pluggy
@@ -9976,7 +10116,7 @@ package:
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -9989,14 +10129,14 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pylint
-  version: 4.0.5
+  version: 4.0.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10009,10 +10149,10 @@ package:
     python: ''
     tomli: '>=1.1'
     tomlkit: '>=0.10.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pylint-4.0.6-pyhcf101f3_0.conda
   hash:
-    md5: 7d9916ed19ecda71f0b00963365252a7
-    sha256: a8e7736982409a56d2aa329d3052259fd45910f98fb7d3f2816f1a6d59624d60
+    md5: ba6813f7d81828b7dcd03248a42d031d
+    sha256: 5393b20b76361efe49971a0081cad0f4256f875a14fe71b1ed93ba9e0193369c
   category: main
   optional: false
 - name: pyobjc-core
@@ -10149,11 +10289,11 @@ package:
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10161,18 +10301,18 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest
-  version: 9.0.3
+  version: 9.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    colorama: '>=0.4'
+    colorama: ''
     exceptiongroup: '>=1'
     iniconfig: '>=1.0.1'
     packaging: '>=22'
@@ -10180,10 +10320,10 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   hash:
-    md5: 6a991452eadf2771952f39d43615bb3e
-    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+    md5: 64c98a12c4e23eb238bf66bbecafdf3c
+    sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   category: main
   optional: false
 - name: pytest-cov
@@ -10299,58 +10439,58 @@ package:
   category: main
   optional: false
 - name: python
-  version: 3.14.5
+  version: 3.14.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.8.0,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
     libgcc: '>=14'
     liblzma: '>=5.8.3,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.53.1,<4.0a0'
+    libsqlite: '>=3.53.2,<4.0a0'
     libuuid: '>=2.42.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     python_abi: 3.14.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
   hash:
-    md5: da92e59ff92f2d5ede4f612af20f583f
-    sha256: 55eed9bf2a3f6e90311276f0834737fe7c2d9ec3e5e2e557507858df4c7521e6
+    md5: 0b9b2f83b5b600e1ac38becde8d0dd44
+    sha256: 6d28ac2b061179deb434d3d57afa98ffd20ec3c5d44ab8048a1ca33424b22d38
   category: main
   optional: false
 - name: python
-  version: 3.14.5
+  version: 3.14.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.0,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
     liblzma: '>=5.8.3,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.53.1,<4.0a0'
+    libsqlite: '>=3.53.2,<4.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     python_abi: 3.14.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
   hash:
-    md5: f7331c9deaf21c79e5675e72b21d570b
-    sha256: 06dec0e2f50e2f7e6a8808fcb4aff23729a3f23bcb1fca4fcbc3a341d9e38a83
+    md5: 4841be3d0cf616a860efc6e60af66f8b
+    sha256: 984081c9fae3a3944c6f2707bbbbc70e8b961f02cdb7c640d9745e2636235632
   category: main
   optional: false
 - name: python-dateutil
@@ -10404,29 +10544,29 @@ package:
   category: main
   optional: false
 - name: python-gil
-  version: 3.14.5
+  version: 3.14.6
   manager: conda
   platform: linux-64
   dependencies:
-    cpython: 3.14.5.*
+    cpython: 3.14.6.*
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.5-h4df99d1_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_100.conda
   hash:
-    md5: 41954747ba952ec4b01e16c2c9e8d8ff
-    sha256: 41dd7da285d71d519257fa7dacb1cae060d5ebfaa5f92cba5994899d2978e943
+    md5: 224f69f177eb5aae6c9a6052846bf609
+    sha256: 84c129bdd6abcecac42a948f2670d17fe735d02d3a5a483a9b1f1bc33ba38c28
   category: main
   optional: false
 - name: python-gil
-  version: 3.14.5
+  version: 3.14.6
   manager: conda
   platform: osx-arm64
   dependencies:
-    cpython: 3.14.5.*
+    cpython: 3.14.6.*
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.5-h4df99d1_100.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_100.conda
   hash:
-    md5: 41954747ba952ec4b01e16c2c9e8d8ff
-    sha256: 41dd7da285d71d519257fa7dacb1cae060d5ebfaa5f92cba5994899d2978e943
+    md5: 224f69f177eb5aae6c9a6052846bf609
+    sha256: 84c129bdd6abcecac42a948f2670d17fe735d02d3a5a483a9b1f1bc33ba38c28
   category: main
   optional: false
 - name: python-json-logger
@@ -10482,7 +10622,7 @@ package:
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10490,24 +10630,24 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.11.0-py314h0f05182_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.12.0-py314h0f05182_0.conda
   hash:
-    md5: 1c6a332e01cd8f81f350434fbf7bcaad
-    sha256: 4529fdc71dcaa13ad25c4708751029c56f507f7d26f1748f20875cea85a158fa
+    md5: fbc3f0267d363cf1ecd689389c9bb67e
+    sha256: f8b608833cd289c9f06f6b528139e53ea1c509a8eb9d4490d15ad76f59def5c6
   category: main
   optional: false
 - name: python-librt
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: 3.14.*
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.11.0-py314ha14b1ff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.12.0-py314ha14b1ff_0.conda
   hash:
-    md5: 68be11fb4ea06efd0e13db21921afe56
-    sha256: 483c34d3224b1d8209206d5eba7b0f36f33a891908eec46d12a7a621d0a39001
+    md5: c12ed5b5eb3e12e9ba67483207199411
+    sha256: 6f2592ed0cc82de7f942af83f34b5a73598d8898322d572cafbdcaf05f9db423
   category: main
   optional: false
 - name: python-tzdata
@@ -10679,7 +10819,7 @@ package:
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -10688,14 +10828,14 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: qp-prob
-  version: 1.0.1
+  version: 1.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10704,10 +10844,10 @@ package:
     python: '>=3.10'
     scipy: '>=1.7.0'
     tables-io: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/qp-prob-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 781ea726ee8b76128ab2d68b26a213b5
-    sha256: c9ccbb7ce03a83a6698deb7383727c47597da9283d97f4e86a95dec25a08a50b
+    md5: 3038342f8a3d22734117907af8e91ad9
+    sha256: 7fe9622864673009189c12375b1e6f901903ada710a647ca38e60986698dd15a
   category: main
   optional: false
 - name: quarto
@@ -11044,7 +11184,7 @@ package:
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -11052,42 +11192,42 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.5.1-py314h1bee95f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py314h1bee95f_0.conda
   hash:
-    md5: fb5b4fc759b225d4f32730cc8380ec8e
-    sha256: 79d753848377c415578f42285f5f87be711503b887c99e8890fd51d3fae1d6a5
+    md5: add3cbcc5eb677f6c1720e01cd82aac5
+    sha256: 064e56d6c233cbcfac5b0183c0dd10b732668ff27aa1ea3580459acceae95473
   category: main
   optional: false
 - name: rpds-py
-  version: 2026.5.1
+  version: 2026.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.5.1-py314he1d1ac0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py314he1d1ac0_0.conda
   hash:
-    md5: 58fe40c3bba570ac2cbfac4f4ea983b7
-    sha256: 764b78892f8ba2a7d5cb24c2911bd5718753ba5b130bf4e0d9a0bb0001c139b1
+    md5: 2e8e2fe25e9d6df3628b068fe7407299
+    sha256: 30bf9b362be5f04ccb7c0d9549f474763fb6fd11e7f0b78e5286b881f3c382cf
   category: main
   optional: false
 - name: s2n
-  version: 1.7.3
+  version: 1.7.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
   hash:
-    md5: f2bd09e21c5844a12e2f5eefcd075555
-    sha256: 150a0a5254e8b15ad737549721c7d13406cd96432f3f446e07073dbd98bb2491
+    md5: a20feedf58ce5441b115cebf284a9a75
+    sha256: de0bb8c7526684c9927cc687d4d07abe09d023a3ec950cfcd61089b495e2e616
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: linux-64
   dependencies:
@@ -11095,14 +11235,14 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: sacc
-  version: 2.1.2
+  version: '2.3'
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11110,10 +11250,10 @@ package:
     numpy: ''
     python: '>=3.10'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sacc-2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ed39d23fe3928e474466dc0a87f0b8c3
-    sha256: 37869108cadceb04a17d34061b5a728383a049cf905be5a7ac28c86f04786ef5
+    md5: 7d68dcd139425555f09628339e4a86fa
+    sha256: 7f596c693ae0ff1db45d900357b17dce87022e27cffa57d8a96f61753705c964
   category: main
   optional: false
 - name: scikit-learn
@@ -11160,7 +11300,7 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -11172,17 +11312,17 @@ package:
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx: '>=14'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
   hash:
-    md5: 718437171257e579e7d1f3b51c62536f
-    sha256: 505e3466e97c16d125a9adb61a80bdfc2fefe62bc9f0bfe798eda88706e4b0ed
+    md5: 62c390c1f8f51240f1ebc7ba782669ad
+    sha256: 85503102237f8515ab92319fc14609e894ac9e95e3a1398b0c49db1f9ee50877
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11193,13 +11333,13 @@ package:
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314h18e1515_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
   hash:
-    md5: 9958307c22c5b53165e46719ebe8972d
-    sha256: d9742c04d44f78d2628899ad017f23e404e08f28118fcfbbf6722259cbd56eab
+    md5: e55fe08bb5d43e7120672338dd129030
+    sha256: 7ce218a4e1c55775547835d21a7ead0d50e5ac348fd638ce6ba316c48c8547b7
   category: main
   optional: false
 - name: sdkroot_env_osx-arm64
@@ -11860,29 +12000,29 @@ package:
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: sphinxcontrib-serializinghtml
-  version: 1.1.10
+  version: 2.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc61f7161d28137797e038263c04c54
-    sha256: 64d89ecc0264347486971a94487cb8d7c65bfc0176750cf7502b8a272f4ab557
+    md5: f77df1fcf9af03b7287342638befca77
+    sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
   category: main
   optional: false
 - name: stack_data
@@ -12025,7 +12165,7 @@ package:
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12035,15 +12175,15 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tables-io
-  version: 1.1.0
+  version: 1.1.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12053,11 +12193,11 @@ package:
     numpy: ''
     pandas: ''
     pytables: ''
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.0-pyh97e8d58_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/tables-io-1.1.2-pyh97e8d58_0.conda
   hash:
-    md5: 63a135a7576aaa90dc13131720b5df19
-    sha256: e2d4607242f1aa0462c17e90b56e1fa7f43c5aeb26a1637fca7370e482b4a191
+    md5: 1fa3608e06fffcd7edf4ddd2be61b2b2
+    sha256: 74abd16921263c21ee7d9815f261aa109d59c2fd8dea2dd148c7a65c1fc0512a
   category: main
   optional: false
 - name: tabulate
@@ -12283,29 +12423,29 @@ package:
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: tqdm
-  version: 4.68.2
+  version: 4.68.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.2-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
   hash:
-    md5: 99ee58c51aae7ee9ab947a0c6ce5a4c7
-    sha256: f3ac3dcc43f011835efe2718f5d78981935e8aa1e1d9741b63499dfdd8fa802c
+    md5: 65094960cb7ed216b6049aab57205902
+    sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
   category: main
   optional: false
 - name: traitlets
@@ -12333,7 +12473,7 @@ package:
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -12342,14 +12482,14 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: typer
-  version: 0.26.7
+  version: 0.26.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12358,10 +12498,10 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.8-pyhcf101f3_0.conda
   hash:
-    md5: 71d2c80673511fab927bd15592994030
-    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+    md5: 8bd9c1e0ff3a31a11e21c3f04c2d0f8b
+    sha256: a97b824609402c81951640f61abe010bdaa728889c23673ac6c43863cb946c45
   category: main
   optional: false
 - name: types-pyyaml
@@ -12694,27 +12834,27 @@ package:
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: wcwidth
-  version: 0.8.1
+  version: 0.8.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 99f7755ec8648a042b0dbe906234f888
+    sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
   category: main
   optional: false
 - name: webcolors
@@ -12814,7 +12954,7 @@ package:
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12822,38 +12962,38 @@ package:
     libgcc: '>=14'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.1-py314h5bd0f2a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
   hash:
-    md5: 7e4cdd7cc4909e0c9e0a75b3d74e1cad
-    sha256: bc53c274d2f7ddbd0ce9212eb72a99d17abe42069e1c78139c5581011ea85bd6
+    md5: e1e275654a6c998b7357606f5da46af7
+    sha256: f2789ff73f60f3b740629146a64f778bbf40e26900978cb632180878a496423c
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.1-py314h6c2aa35_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
   hash:
-    md5: b7af50eb697b32997d38bc0af06010d3
-    sha256: 2f419160ec31de3ca3501e8a831a386a471f6c5e1dc43a57f3f3bcd1cf77e6b0
+    md5: abca357e08d7ceaaeebafa6d7f5a7fad
+    sha256: 3fff09a8c28dbdd3280c767f0b09ab5a25bcda2ed3b0a07b48a5b986e0ff12df
   category: main
   optional: false
 - name: xkeyboard-config
-  version: '2.47'
+  version: '2.48'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
   hash:
-    md5: b56e0c8432b56decafae7e78c5f29ba5
-    sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
+    md5: b233b41be0bf210989d57160ed39b394
+    sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
   category: main
   optional: false
 - name: xorg-libice

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ coverage.json
 
 **/*.quarto_ipynb
 .ruff_cache
+.github/instructions/
+.headroom
+.kilo
+plans/

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - quarto
   - requests
   - rich
-  - sacc >= 2.1
+  - sacc >= 2.3
   - scipy >= 1.13
   - sphinx
   - sphinx-autoapi

--- a/examples/cluster_number_counts/cluster_redshift_richness_reduced_shear.py
+++ b/examples/cluster_number_counts/cluster_redshift_richness_reduced_shear.py
@@ -110,7 +110,7 @@ def build_likelihood(
     sacc_path = os.path.expanduser(
         os.path.expandvars("${FIRECROWN_DIR}/examples/cluster_number_counts/")
     )
-    sacc_data = sacc.Sacc.load_fits(os.path.join(sacc_path, sacc_file_nm))
+    sacc_data = sacc.Sacc.load(os.path.join(sacc_path, sacc_file_nm))
     likelihood.read(sacc_data)
 
     modeling_tools = ModelingTools()

--- a/firecrown/app/sacc/_transform.py
+++ b/firecrown/app/sacc/_transform.py
@@ -9,6 +9,8 @@ from typing import Annotated, assert_never
 import sacc
 import typer
 
+from sacc.utils import detect_sacc_file_type
+
 from firecrown.metadata_functions import (
     extract_all_real_metadata_indices,
     extract_all_harmonic_metadata_indices,
@@ -159,29 +161,19 @@ data.h5
 
     @staticmethod
     def detect_format(filepath: Path) -> SaccFormat:
-        """Detect file format from extension or file contents."""
-        suffix = filepath.suffix.lower()
+        """Detect file format using sacc's own file-type detection."""
+        try:
+            file_type = detect_sacc_file_type(str(filepath))
+        except ValueError as e:
+            raise ValueError(f"Cannot detect format of '{filepath}': {e}") from e
 
-        match suffix:
-            case ".fits":
+        match file_type:
+            case "fits":
                 return SaccFormat.FITS
-            case ".hdf5" | ".h5":
+            case "hdf5":
                 return SaccFormat.HDF5
-            case _:
-                try:
-                    sacc.Sacc.load_fits(str(filepath))
-                    return SaccFormat.FITS
-                except OSError:
-                    pass
-                try:
-                    sacc.Sacc.load_hdf5(str(filepath))
-                    return SaccFormat.HDF5
-                except OSError:
-                    pass
-                raise ValueError(
-                    f"Cannot detect format from extension '{suffix}'. "
-                    "Use --input-format to specify."
-                )
+            case _ as unreachable:
+                assert_never(unreachable)
 
     def _determine_output_path(
         self, input_path: Path, output: Path | None, target_format: SaccFormat
@@ -256,15 +248,17 @@ data.h5
         self.console.print(
             f"Reading {src_format.upper()} file: [cyan]{self.sacc_file}[/cyan]"
         )
+        match src_format:
+            case SaccFormat.FITS | "fits":
+                loader = sacc.Sacc.load_fits
+            case SaccFormat.HDF5 | "hdf5":
+                loader = sacc.Sacc.load_hdf5
+            case _:
+                raise ValueError(f"Unknown input format: {src_format}")
+
         try:
-            match src_format:
-                case SaccFormat.FITS | "fits":
-                    return sacc.Sacc.load_fits(str(self.sacc_file))
-                case SaccFormat.HDF5 | "hdf5":
-                    return sacc.Sacc.load_hdf5(str(self.sacc_file))
-                case _:
-                    raise ValueError(f"Unknown input format: {src_format}")
-        except OSError:
+            return loader(str(self.sacc_file))
+        except (OSError, ValueError):
             self.console.print(
                 "[bold red]ERROR: Failed to read input file as SACC data.[/bold red]"
             )

--- a/firecrown/likelihood/factories/_sacc_utils.py
+++ b/firecrown/likelihood/factories/_sacc_utils.py
@@ -9,14 +9,13 @@ from typing_extensions import assert_never
 def load_sacc_data(filepath: str | Path) -> sacc.Sacc:
     """Load SACC data from a file, auto-detecting the format.
 
-    Attempts to load the file first as HDF5, then as FITS if HDF5 fails.
-    This allows the function to work with both modern HDF5-based SACC files
-    and legacy FITS-based SACC files.
+    Delegates to sacc.Sacc.load(), which auto-detects FITS vs HDF5 based on
+    filename extension or (for ambiguous extensions like .sacc) file content.
 
     :param filepath: Path to the SACC data file (str or Path object)
     :return: Loaded SACC data object
     :raises FileNotFoundError: If the file does not exist
-    :raises ValueError: If the file cannot be read as either HDF5 or FITS SACC data
+    :raises ValueError: If the file cannot be recognized as SACC data
     """
     # Convert to Path object for consistent handling
     file_path = Path(filepath) if isinstance(filepath, str) else filepath
@@ -25,27 +24,10 @@ def load_sacc_data(filepath: str | Path) -> sacc.Sacc:
     if not file_path.exists():
         raise FileNotFoundError(f"SACC file not found: {file_path}")
 
-    # Try HDF5 first (modern format)
-    hdf5_error = None
     try:
-        return sacc.Sacc.load_hdf5(str(file_path))
-    except OSError as e:
-        hdf5_error = e
-
-    # If HDF5 failed, try FITS (legacy format)
-    fits_error = None
-    try:
-        return sacc.Sacc.load_fits(str(file_path))
-    except OSError as e:
-        fits_error = e
-
-    # Both formats failed - provide helpful error message
-    raise ValueError(
-        f"Failed to load SACC data from file: {file_path}\n"
-        f"The file could not be read as either HDF5 or FITS format.\n"
-        f"HDF5 error: {hdf5_error}\n"
-        f"FITS error: {fits_error}"
-    )
+        return sacc.Sacc.load(str(file_path))
+    except ValueError as e:
+        raise ValueError(f"Failed to load SACC data from file: {file_path}\n{e}") from e
 
 
 def ensure_path(file: str | Path) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pydantic",
     "pyyaml",
     "rich",
-    "sacc",
+    "sacc>=2.3",
     "scipy",
     "typer",
 ]

--- a/tests/app/sacc/test_sacc_transform.py
+++ b/tests/app/sacc/test_sacc_transform.py
@@ -316,6 +316,18 @@ class TestTransformFormatDetection:
 
         assert output_file.exists()
 
+    def test_detect_sacc_file_type_importable(self) -> None:
+        """Guard test: sacc.utils.detect_sacc_file_type must remain importable.
+
+        Transform.detect_format relies on this internal-but-stable sacc
+        helper. If a future sacc release renames or removes it, this test
+        will fail loudly instead of Transform.detect_format failing silently.
+        """
+        # pylint: disable=import-outside-toplevel
+        from sacc.utils import detect_sacc_file_type
+
+        assert callable(detect_sacc_file_type)
+
 
 class TestTransformIntegration:
     """Integration tests for Transform functionality."""

--- a/tests/likelihood/test_factories.py
+++ b/tests/likelihood/test_factories.py
@@ -1174,12 +1174,35 @@ def test_load_sacc_data_both_formats_fail(tmp_path):
     with pytest.raises(
         ValueError,
         match=re.compile(
-            "Failed to load SACC data from file.*"
-            "The file could not be read as either HDF5 or FITS format",
+            "Failed to load SACC data from file.*Could not detect file type",
             re.DOTALL,
         ),
     ):
         load_sacc_data(bad_file)
+
+
+def test_load_sacc_data_ambiguous_extension_hdf5_content(tmp_path):
+    """Test load_sacc_data loads a .sacc-suffixed file with HDF5 content."""
+    hdf5_file = tmp_path / "data.sacc"
+    s = sacc.Sacc()
+    s.add_tracer("misc", "tracer1")
+    s.save_hdf5(str(hdf5_file))
+
+    sacc_data = load_sacc_data(hdf5_file)
+    assert sacc_data is not None
+    assert isinstance(sacc_data, sacc.Sacc)
+
+
+def test_load_sacc_data_ambiguous_extension_fits_content(tmp_path):
+    """Test load_sacc_data loads a .sacc-suffixed file with FITS content."""
+    fits_file = tmp_path / "data.sacc"
+    s = sacc.Sacc()
+    s.add_tracer("misc", "tracer1")
+    s.save_fits(str(fits_file))
+
+    sacc_data = load_sacc_data(fits_file)
+    assert sacc_data is not None
+    assert isinstance(sacc_data, sacc.Sacc)
 
 
 def test_load_sacc_data_with_path_object():

--- a/tutorial/.gitignore
+++ b/tutorial/.gitignore
@@ -21,3 +21,4 @@ systematics_files/
 _freeze/
 
 **/*.quarto_ipynb
+docs/


### PR DESCRIPTION
## Description

This PR migrates Firecrown's SACC file detection and loading logic to use the unified API introduced in `sacc` 2.3. It removes manual probing logic and fixes a bug where mismatched file formats caused unhandled `ValueError` exceptions during transformation.

### Core Logic Refactor

Unified Loading: Updated `firecrown.likelihood.factories._sacc_utils.load_sacc_data` to use `sacc.Sacc.load()`, delegating auto-detection of file formats to the `sacc` library.

Format Detection: Reimplemented `firecrown.app.sacc._transform.Transform.detect_format` to use `sacc.utils.detect_sacc_file_type`. This ensures consistency between Firecrown's detection and sacc's internal loading behavior.

Error Handling: Fixed `Transform._read_sacc_data` to catch both `OSError` and `ValueError` when a user forces an incorrect input format via CLI, preventing unhandled exception crashes.

### Dependency & Tooling

Dependency Pinning: Updated `pyproject.toml` to require `sacc`>=2.3.
Conda Lockfiles: Updated conda-lock files to synchronize with the environment and dependency updates.
Tooling: Updated `.gitignore` to exclude local tooling and tutorial documentation artifacts.

### Testing & Validation

Regression Tests: Added tests in `tests/likelihood/test_factories.py` to verify that .sacc-suffixed files containing either HDF5 or FITS content are correctly auto-detected and loaded.

Guard Test: Added a test case to ensure `sacc.utils.detect_sacc_file_type `remains importable, protecting against future breaking changes in the sacc internal API.

### Related Issues

Fixes issue where `sacc` 2.3 raised `ValueError` instead of `OSError` during format probing, breaking the fallback mechanism in `Transform.detect_format` and `load_sacc_data`.

## Type of change

Please delete the bullet items below that do not apply to this pull request.

This is backwards-compatible in terms of API, but requires users update to SACC 2.3, which is a breaking change of sorts.

## Checklist

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

* [x] I have run `make pre-commit` and fixed any issues
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have made corresponding changes to the documentation
* [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
