### PR TITLE
Fixing theory/data-vector subclassing numpy arrays instead of type-hint.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ dependencies:
   - alabaster
   - babel
   - black
+  - camb < 2.0
   - charset-normalizer
   - clmm
   - compilers

--- a/firecrown/data_types/_vectors.py
+++ b/firecrown/data_types/_vectors.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 
 
-class DataVector(npt.NDArray[np.float64]):
+class DataVector(np.ndarray):
     """Wrapper for a np.ndarray that represents some observed data values."""
 
     @classmethod
@@ -33,7 +33,7 @@ class DataVector(npt.NDArray[np.float64]):
         return cls.create(array)
 
 
-class TheoryVector(npt.NDArray[np.float64]):
+class TheoryVector(np.ndarray):
     """Wrapper for an np.ndarray that represents a prediction by some theory."""
 
     @classmethod


### PR DESCRIPTION
## Description

Fixing theory/data-vector subclassing numpy arrays instead of type-hint.

## Type of change

Please delete the bullet items below that do not apply to this pull request.

* Bug fix (non-breaking change which fixes an issue)

## Checklist

The following checklist will make sure that you are following the code style and
guidelines of the project as described in the
[contributing](https://firecrown.readthedocs.io/en/latest/contrib.html) page.

* [x] I have run `make pre-commit` and fixed any issues
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have made corresponding changes to the documentation
* [x] I have 100% test coverage for my changes (please check this after the CI system has verified the coverage)
